### PR TITLE
Update getSessionsForToday

### DIFF
--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/cache/ResourceDatabaseHelper.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/cache/ResourceDatabaseHelper.kt
@@ -6,6 +6,7 @@ import com.squareup.sqldelight.runtime.coroutines.asFlow
 import com.squareup.sqldelight.runtime.coroutines.mapToList
 import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 class ResourceDatabaseHelper(sqlDriver: SqlDriver) {
     internal val database = BridgeResourceDatabase(
@@ -22,7 +23,7 @@ class ResourceDatabaseHelper(sqlDriver: SqlDriver) {
     }
 
     internal fun getResourceAsFlow(id: String, type: ResourceType, studyId: String): Flow<Resource?> {
-        return dbQuery.selectResourceById(id, type, studyId).asFlow().mapToOneOrNull()
+        return dbQuery.selectResourceById(id, type, studyId).asFlow().mapToOneOrNull().distinctUntilChanged(areEquivalent = {old, new -> old == new })
     }
 
     internal fun getResource(id: String, type: ResourceType, studyId: String): Resource? {
@@ -55,7 +56,7 @@ class ResourceDatabaseHelper(sqlDriver: SqlDriver) {
     }
 
     internal fun getResourcesAsFlow(type: ResourceType, studyId: String): Flow<List<Resource>> {
-        return dbQuery.selectAllResourcesByType(type, studyId).asFlow().mapToList()
+        return dbQuery.selectAllResourcesByType(type, studyId).asFlow().mapToList().distinctUntilChanged(areEquivalent = {old, new -> old == new })
     }
 
     internal fun getResources(type: ResourceType, studyId: String): List<Resource> {

--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/di/Koin.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/di/Koin.kt
@@ -25,7 +25,7 @@ val commonModule = module {
     single {ResourceDatabaseHelper(get())}
 
     single<AssessmentConfigRepo> {AssessmentConfigRepo(get(), get(), get(named("background"))) }
-    single<ScheduleTimelineRepo> {ScheduleTimelineRepo(get(), get(), get(), get(named("background"))) }
+    single<ScheduleTimelineRepo> {ScheduleTimelineRepo(get(), get(), get(), get(), get(named("background"))) }
     single<ActivityEventsRepo> { ActivityEventsRepo(get(), get(), get(named("background"))) }
     single<AdherenceRecordRepo> { AdherenceRecordRepo(get(), get(), get(named("background"))) }
     single<AuthenticationRepository> {AuthenticationRepository(get(named("authHttpClient")), get(), get())}

--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/AbstractResourceRepo.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/AbstractResourceRepo.kt
@@ -5,6 +5,7 @@ import io.ktor.http.*
 import io.ktor.util.network.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -31,7 +32,7 @@ abstract class AbstractResourceRepo(val database: ResourceDatabaseHelper, protec
                 }
             }
             filterResource
-        }.map {
+        }.distinctUntilChanged(areEquivalent = {old, new -> old?.json == new?.json}).map {
             processResult(it)
         }
 
@@ -39,7 +40,7 @@ abstract class AbstractResourceRepo(val database: ResourceDatabaseHelper, protec
 
     companion object {
 
-        const val defaultUpdateFrequency = 10000// 60000 * 60
+        const val defaultUpdateFrequency = 60000// 1 minute
 
         internal suspend fun remoteLoadResource(
             database: ResourceDatabaseHelper,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
-        classpath("com.android.tools.build:gradle:4.1.3")
+        classpath("com.android.tools.build:gradle:4.2.1")
         classpath("com.squareup.sqldelight:gradle-plugin:${Versions.sqlDelight}")
         classpath("org.jetbrains.kotlin:kotlin-serialization:${Versions.kotlin}")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 allprojects {
     group = "org.sagebionetworks.bridge.kmm"
-    version = "0.2.16"
+    version = "0.2.17"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
- No longer need to pass in activity events list 
- Will emit new value anytime cached values for events, timeline, or adherence records change
- Should only emit a value when there really was a change.