### PR TITLE
Schedules with next up

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/Extensions/Date+Utils.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Extensions/Date+Utils.swift
@@ -65,4 +65,11 @@ extension Date {
             return DateFormatter.localizedString(from: self, dateStyle: .medium, timeStyle: .short)
         }
     }
+    
+}
+
+extension Kotlinx_datetimeInstant {
+    public var dateValue: Date {
+        Date(timeIntervalSince1970: Double(self.toEpochMilliseconds()) * 0.001)
+    }
 }

--- a/SwiftPackage/Sources/BridgeClientUI/Extensions/NativeScheduledSessionWindow+View.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Extensions/NativeScheduledSessionWindow+View.swift
@@ -56,3 +56,4 @@ extension NativeScheduledSessionWindow {
         endDateTime.localizeDate(hasTimeOfDay: hasEndTimeOfDay)
     }
 }
+

--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/ScheduleTimelineRepo.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/ScheduleTimelineRepo.kt
@@ -35,35 +35,50 @@ class ScheduleTimelineRepo(internal val adherenceRecordRepo: AdherenceRecordRepo
     )
 
     private fun getTimeline(studyId: String): Flow<ResourceResult<Timeline>> {
-        return getResourceById(SCHEDULE_TIMELINE_ID+studyId, remoteLoad =  { loadRemoteTimeline(studyId) }, studyId = studyId)
+        return getResourceById(
+            SCHEDULE_TIMELINE_ID + studyId,
+            remoteLoad = { loadRemoteTimeline(studyId) },
+            studyId = studyId
+        )
     }
 
-    private suspend fun loadRemoteTimeline(studyId: String) : String {
+    private suspend fun loadRemoteTimeline(studyId: String): String {
         return Json.encodeToString(scheduleApi.getTimelineForUser(studyId))
     }
 
     /**
      * Get all the scheduled sessions for today that have not expired.
      */
-    fun getSessionsForToday(studyId: String) : Flow<ResourceResult<List<ScheduledSessionWindow>>> {
+    fun getSessionsForToday(studyId: String): Flow<ResourceResult<List<ScheduledSessionWindow>>> {
         return getSessionsForDay(studyId, Clock.System.now())
     }
 
     /**
      * Used for testing so that we can specify a consistent point in time.
      */
-    internal fun getSessionsForDay(studyId: String, instantInDay: Instant) : Flow<ResourceResult<List<ScheduledSessionWindow>>> {
-        return combine(getTimeline(studyId), activityEventsRepo.getActivityEvents(studyId), adherenceRecordRepo.getAllCachedAdherenceRecords(studyId)) { timeLineResource, eventsResource, adherence ->
-            extractSessionsForDay(timeLineResource, eventsResource, adherence, studyId, instantInDay)
+    internal fun getSessionsForDay(
+        studyId: String,
+        instantInDay: Instant
+    ): Flow<ResourceResult<List<ScheduledSessionWindow>>> {
+        return combine(
+            getTimeline(studyId),
+            activityEventsRepo.getActivityEvents(studyId)
+        ) { timeLineResource, eventsResource ->
+            extractSessionsForDay(
+                timeLineResource,
+                eventsResource,
+                studyId,
+                instantInDay
+            )
         }
     }
 
-    private fun extractSessionsForDay(timelineResult: ResourceResult<Timeline>,
-                                        eventsResult: ResourceResult<StudyActivityEventList>,
-                                        adherenceRecords: Map<String, List<AdherenceRecord>>,
-                                        studyId: String,
-                                        instantInDay: Instant
-                                        ) : ResourceResult<List<ScheduledSessionWindow>> {
+    private fun extractSessionsForDay(
+        timelineResult: ResourceResult<Timeline>,
+        eventsResult: ResourceResult<StudyActivityEventList>,
+        studyId: String,
+        instantInDay: Instant
+    ): ResourceResult<List<ScheduledSessionWindow>> {
         return when (eventsResult) {
             is ResourceResult.Success -> {
                 return extractSessions(eventsResult.data, timelineResult, instantInDay, studyId)
@@ -73,11 +88,23 @@ class ScheduleTimelineRepo(internal val adherenceRecordRepo: AdherenceRecordRepo
         }
     }
 
-    private fun extractSessions(eventList: StudyActivityEventList, resource: ResourceResult<Timeline>, instantInDay: Instant, studyId: String): ResourceResult<List<ScheduledSessionWindow>> {
+    private fun extractSessions(
+        eventList: StudyActivityEventList,
+        resource: ResourceResult<Timeline>,
+        instantInDay: Instant,
+        studyId: String
+    ): ResourceResult<List<ScheduledSessionWindow>> {
         return when (resource) {
             is ResourceResult.Success -> {
                 val timeline = resource.data
-                ResourceResult.Success(extractSessionsForDay(eventList, timeline, instantInDay, studyId), resource.status)
+                ResourceResult.Success(
+                    extractSessionsForDay(
+                        eventList,
+                        timeline,
+                        instantInDay,
+                        studyId
+                    ), resource.status
+                )
             }
             is ResourceResult.InProgress -> resource
             is ResourceResult.Failed -> resource
@@ -90,162 +117,170 @@ class ScheduleTimelineRepo(internal val adherenceRecordRepo: AdherenceRecordRepo
      * day specified by [instantInDay]. Sessions that expire before [instantInDay] will be excluded.
      */
     @OptIn(ExperimentalTime::class)
-    private fun extractSessionsForDay(eventList: StudyActivityEventList, timeline: Timeline, instantInDay: Instant, studyId: String) : List<ScheduledSessionWindow> {
+    private fun extractSessionsForDay(
+        eventList: StudyActivityEventList,
+        timeline: Timeline,
+        instantInDay: Instant,
+        studyId: String,
+        includeExpired: Boolean = false,
+        timezone: TimeZone = TimeZone.currentSystemDefault(),
+    ): List<ScheduledSessionWindow> {
+        return extractSessionWindows(
+            eventList,
+            timeline,
+            instantInDay,
+            studyId,
+            false,
+            includeExpired,
+            timezone
+        )
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun extractSessionWindows(
+        eventList: StudyActivityEventList,
+        timeline: Timeline,
+        instantInDay: Instant,
+        studyId: String,
+        future: Boolean,
+        includeExpired: Boolean,
+        timezone: TimeZone,
+    ): List<ScheduledSessionWindow> {
+
         // Map of eventID to SessionInfo
-        val sessionInfoMap = timeline.sessions?.groupBy({it.startEventId})
+        val sessionInfoMap = timeline.sessions?.groupBy { it.startEventId } ?: return emptyList()
         // Map of key to AssessmentInfo
-        val assessmentInfoMap = timeline.assessments?.associateBy({it.key}, {it})
+        val assessmentInfoMap =
+            timeline.assessments?.associateBy({ it.key }, { it }) ?: return emptyList()
         // Map of Session Guid to ScheduledSessionList
-        val scheduleSessionMap = timeline.schedule?.groupBy({it.refGuid})
-
-        if (sessionInfoMap == null || assessmentInfoMap == null || scheduleSessionMap == null) {
-            return emptyList()
-        }
-
+        val scheduleSessionMap = timeline.schedule?.groupBy { it.refGuid } ?: return emptyList()
         // Get date portion of instantInDay
-        val day: LocalDate = instantInDay.toLocalDateTime(TimeZone.currentSystemDefault()).date
+        val day: LocalDate = instantInDay.toLocalDateTime(timezone).date
 
-        val scheduledSessionWindowList = mutableListOf<ScheduledSessionWindow>()
-        eventList.items?.let {
-            for (event in eventList.items) {
-                // Convert the event timestamp to a LocalDate
-                val eventLocalDate = event.timestamp.toLocalDateTime(TimeZone.currentSystemDefault()).date
-                // Get number of days since the event date
-                val daysSince = eventLocalDate.daysUntil(day)
+        val events = eventList.items ?: return emptyList()
+        return events.map { event ->
+            // Convert the event timestamp to a LocalDate
+            val eventLocalDate = event.timestamp.toLocalDateTime(timezone).date
+            // Get number of days since the event date
+            val daysSince = eventLocalDate.daysUntil(day)
 
-                sessionInfoMap.get(event.eventId)?.let { sessionInfoList ->
-                    for (session in sessionInfoList) {
-                        //Find the list of scheduled sessions for the given session
-                        val scheduledSessionList = scheduleSessionMap[session.guid]
-                        //Filter the list to today's sessions (start on or before and end on or after today)
-                        scheduledSessionList?.filter { it.startDay <= daysSince && it.endDay >= daysSince }
-                            ?.let { todaySessionList ->
-                                for (scheduledSession in todaySessionList) {
-                                    var includeSession = true
-                                    // For sessions with an expiration we need to check if it is passed
-
-                                    //Used for sorting when sessions span multiple days
-                                    val startDaysFromToday = scheduledSession.startDay - daysSince
-                                    val startDate = day.plus(startDaysFromToday.toLong(), DateTimeUnit.DateBased.DayBased(1))
-
-                                    // LocalTime support is hopefully coming: https://github.com/Kotlin/kotlinx-datetime/issues/57#issuecomment-800287971
-                                    // Construct a startDateTime from today and startTime
-                                    val startDateTimeString =
-                                        startDate.toString() + "T" + scheduledSession.startTime
-                                    val startDateTime = LocalDateTime.parse(startDateTimeString)
-
-                                    val startInstant =
-                                        startDateTime.toInstant(TimeZone.currentSystemDefault())
-                                    val expirationInstant = startInstant.plus(
-                                        scheduledSession.expiration,
-                                        TimeZone.currentSystemDefault()
-                                    )
-                                    if ((expirationInstant.toEpochMilliseconds() - instantInDay.toEpochMilliseconds()) < 0) {
-                                        // Expiration is in the past so don't include it
-                                        includeSession = false
-                                    }
-                                    val endDateTime = expirationInstant.toLocalDateTime(TimeZone.currentSystemDefault())
-
-
-                                    if (includeSession) {
-                                        val adherenceRecords = adherenceRecordRepo.getCachedAdherenceRecords(scheduledSession.assessments.map { it.instanceGuid }, studyId)
-                                        val assessmentList = scheduledSession.assessments.map {assessment ->
-                                            val recordsList = adherenceRecords.get(assessment.instanceGuid)
-                                            ScheduledAssessmentReference(
-                                                instanceGuid = assessment.instanceGuid,
-                                                assessmentInfo = assessmentInfoMap[assessment.refKey]!!,
-                                                adherenceRecordList = recordsList
-                                            )
-                                        }
-
-
-                                        val sessionWindow =
-                                            ScheduledSessionWindow.createScheduledSessionWindow(
-                                                scheduledSession = scheduledSession,
-                                                sessionInfo = session,
-                                                assessments = assessmentList,
-                                                startDaysFromToday = startDaysFromToday,
-                                                eventTimeStamp = event.timestamp,
-                                                startDateTime = startDateTime,
-                                                endDateTime = endDateTime
-                                            )
-                                        scheduledSessionWindowList.add(sessionWindow)
-                                    }
-                                }
-                            }
-                    }
+            val sessions = sessionInfoMap[event.eventId] ?: emptyList()
+            sessions.map { session ->
+                //Find the list of scheduled sessions for the given session
+                val scheduledSessionList = scheduleSessionMap[session.guid] ?: emptyList()
+                //Filter the list to today's sessions (start on or before and end on or after today)
+                scheduledSessionList.filterByDaysSince(daysSince, future)
+                    .mapNotNull { scheduledSession ->
+                        createScheduledSessionWindow(
+                            scheduledSession,
+                            daysSince,
+                            day,
+                            instantInDay,
+                            studyId,
+                            assessmentInfoMap,
+                            session,
+                            event,
+                            includeExpired,
+                            timezone
+                        )
                 }
-            }
+            }.flatten()
+        }.flatten()
+        .sortedBy { it.startDateTime }
+    }
+
+    private fun List<ScheduledSession>.filterByDaysSince(daysSince: Int, future: Boolean): List<ScheduledSession> {
+        return if (future) filter { it.startDay > daysSince }
+        else filter { it.startDay <= daysSince && it.endDay >= daysSince }
+    }
+
+    private fun createScheduledSessionWindow(
+        scheduledSession: ScheduledSession,
+        daysSince: Int,
+        day: LocalDate,
+        instantInDay: Instant,
+        studyId: String,
+        assessmentInfoMap: Map<String?, AssessmentInfo>,
+        session: SessionInfo,
+        event: StudyActivityEvent,
+        includeExpired: Boolean,
+        timezone: TimeZone,
+    ): ScheduledSessionWindow? {
+        // For sessions with an expiration we need to check if it is passed
+
+        //Used for sorting when sessions span multiple days
+        val startDaysFromToday = scheduledSession.startDay - daysSince
+        val startDate = day.plus(startDaysFromToday.toLong(), DateTimeUnit.DateBased.DayBased(1))
+
+        // LocalTime support is hopefully coming: https://github.com/Kotlin/kotlinx-datetime/issues/57#issuecomment-800287971
+        // Construct a startDateTime from today and startTime
+        val startDateTimeString =
+            startDate.toString() + "T" + scheduledSession.startTime
+        val startDateTime = LocalDateTime.parse(startDateTimeString)
+
+        val startInstant = startDateTime.toInstant(timezone)
+        val expirationInstant = startInstant.plus(scheduledSession.expiration, timezone)
+
+        val endDateTime = expirationInstant.toLocalDateTime(timezone)
+        val isExpired = (expirationInstant < instantInDay)
+
+        // Expiration is in the past so don't include it
+        return if (includeExpired || !isExpired)
+            ScheduledSessionWindow(
+                scheduledSession = scheduledSession,
+                sessionInfo = session,
+                assessments = mapAssessments(scheduledSession, studyId, assessmentInfoMap),
+                event = event,
+                isExpired = isExpired,
+                startDateTime = startDateTime,
+                endDateTime = endDateTime
+            ) else null
+    }
+
+    private fun mapAssessments(
+        scheduledSession: ScheduledSession,
+        studyId: String,
+        assessmentInfoMap: Map<String?, AssessmentInfo>
+    ): List<ScheduledAssessmentReference> {
+
+        val adherenceRecords = adherenceRecordRepo.getCachedAdherenceRecords(
+            scheduledSession.assessments.map { it.instanceGuid },
+            studyId
+        )
+
+        return scheduledSession.assessments.map { assessment ->
+            val recordsList = adherenceRecords[assessment.instanceGuid]
+            ScheduledAssessmentReference(
+                instanceGuid = assessment.instanceGuid,
+                assessmentInfo = assessmentInfoMap[assessment.refKey]!!,
+                adherenceRecordList = recordsList
+            )
         }
-        // Order session windows first by startDaysFromToday, then by startTime
-        scheduledSessionWindowList.sortWith(compareBy({ it.startDaysFromToday}, {it.startTime}))
-        return scheduledSessionWindowList
     }
 }
 
-
 data class ScheduledSessionWindow (
-
-    val refGuid: String? = null,
-    val instanceGuid: String,
-    val eventTimeStamp: Instant,
-    val startDaysFromToday: Int,
+    val scheduledSession: ScheduledSession,
+    val event: StudyActivityEvent,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime,
-
-    val startDay: Int,
-    val endDay: Int,
-    val startTime: String? = null,
-    val delayTime: String? = null,
-    val expiration: DateTimePeriod? = null,
-    val persistent: Boolean = false,
+    val isExpired: Boolean,
     val assessments: List<ScheduledAssessmentReference>,
     val sessionInfo: SessionInfo
 ) {
-
-    /**
-     * Session is completed if all assessments are completed and it is not persistent
-     */
-    val isCompleted = assessments.find { !it.isCompleted } == null && !persistent
-
-    companion object {
-
-        fun createScheduledSessionWindow(
-            scheduledSession: ScheduledSession,
-            sessionInfo: SessionInfo,
-            assessments: List<ScheduledAssessmentReference>,
-            startDaysFromToday: Int,
-            eventTimeStamp: Instant,
-            startDateTime: LocalDateTime,
-            endDateTime: LocalDateTime,
-            ): ScheduledSessionWindow {
-
-            return ScheduledSessionWindow(
-                refGuid = scheduledSession.refGuid,
-                instanceGuid = scheduledSession.instanceGuid,
-                eventTimeStamp = eventTimeStamp,
-                startDay = scheduledSession.startDay,
-                endDay = scheduledSession.endDay,
-                startTime = scheduledSession.startTime,
-                delayTime = scheduledSession.delayTime,
-                expiration = scheduledSession.expiration,
-                persistent = scheduledSession.persistent,
-                sessionInfo = sessionInfo,
-                assessments = assessments,
-                startDaysFromToday = startDaysFromToday,
-                startDateTime = startDateTime,
-                endDateTime = endDateTime
-            )
-        }
-
-    }
+    val instanceGuid = scheduledSession.instanceGuid
+    val eventTimeStamp = event.timestamp
+    val hasStartTimeOfDay = startDateTime.hour == 0 && startDateTime.minute == 0
+    val hasEndTimeOfDay = scheduledSession.expiration.let { it.hours > 0 || it.minutes > 0 }
+    val isCompleted = assessments.all { it.isCompleted || it.isDeclined }
+    val persistent = scheduledSession.persistent
 }
 
 data class ScheduledAssessmentReference (
-    val instanceGuid: kotlin.String,
+    val instanceGuid: String,
     val assessmentInfo: AssessmentInfo,
     val adherenceRecordList: List<AdherenceRecord>?,
 ) {
     val isCompleted = adherenceRecordList?.let { records -> records.any { it.finishedOn != null }} ?: false
-    val isDeclined = adherenceRecordList?.let { records -> records.any { it.declined == true }} ?: false
+    val isDeclined = !isCompleted && adherenceRecordList?.let { records -> records.any { it.declined == true }} ?: false
 }

--- a/bridge-client/src/iosMain/kotlin/org/sagebionetworks/bridge/kmm/shared/NativeTimelineManager.kt
+++ b/bridge-client/src/iosMain/kotlin/org/sagebionetworks/bridge/kmm/shared/NativeTimelineManager.kt
@@ -65,8 +65,8 @@ internal fun ScheduledSessionWindow.toNative() : NativeScheduledSessionWindow =
         startDateTime = startDateTime.toNSDateComponents().date ?: NSDate.distantPast(),
         endDateTime = endDateTime.toNSDateComponents().date ?: NSDate.distantFuture(),
         persistent = persistent,
-        hasStartTimeOfDay = startTime != null,
-        hasEndTimeOfDay = expiration?.let { it.hours > 0 || it.minutes > 0 } ?: false,
+        hasStartTimeOfDay = hasStartTimeOfDay,
+        hasEndTimeOfDay = hasEndTimeOfDay,
         assessments = assessments.map { it.toNative() },
         sessionInfo = sessionInfo,
     )


### PR DESCRIPTION
I figure may as well *not* optimize until we need to so I am just getting all the future schedules and then filtering out the schedules for the "next up" day. 

This also can be used on iOS to set up notifications at a later time.

Additionally, I "Kotlined" the code some. Mostly just fixed warnings about get(0) and cleaned up the extraction function to make it more readable. FYI, it's better to use `forEach` and then exit early with `return@forEach` or to use`map` and `flatten` when running this kind of stuff. Makes it easier to extract, refactor, and read. 