### PR TITLE
Fix get sessions

### DIFF
--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/ScheduleTimelineRepo.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/ScheduleTimelineRepo.kt
@@ -62,8 +62,11 @@ class ScheduleTimelineRepo(internal val adherenceRecordRepo: AdherenceRecordRepo
     ): Flow<ResourceResult<List<ScheduledSessionWindow>>> {
         return combine(
             getTimeline(studyId),
-            activityEventsRepo.getActivityEvents(studyId)
-        ) { timeLineResource, eventsResource ->
+            activityEventsRepo.getActivityEvents(studyId),
+            //Need to include call to get AdherenceRecords as part of the combine.
+            //This will trigger the flow to emit a new value anytime the AdherenceRecords change.
+            adherenceRecordRepo.getAllCachedAdherenceRecords(studyId)
+        ) { timeLineResource, eventsResource, adherenceRecords ->
             extractSessionsForDay(
                 timeLineResource,
                 eventsResource,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 allprojects {
     group = "org.sagebionetworks.bridge.kmm"
-    version = "0.2.17"
+    version = "0.2.18"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
Even though the result from it is currently unused, we need to include a call to get adherence records in the combine portion of getSessionsForToday. This will trigger the resulting flow to emit a new value anytime the adherence records cache is updated.