### PR TITLE
Add back in work-around to allow building for Android

### DIFF
--- a/bridge-client/build.gradle.kts
+++ b/bridge-client/build.gradle.kts
@@ -27,7 +27,26 @@ kotlin {
         publishAllLibraryVariants()
     }
 
-    ios {
+    // This bit is here to build the XCFramework. syoung 07/02/21
+    if (project.findProperty("XCFRAMEWORK") == "true") {
+        ios {
+            binaries {
+                framework {
+                    baseName = iosFrameworkName
+                }
+            }
+        }
+    }
+
+    // This bit is here so that running `./gradlew build` will work. syoung 07/02/21
+    // Block from https://github.com/cashapp/sqldelight/issues/2044#issuecomment-721299517.
+    val iOSTargetName  = System.getenv("SDK_NAME") ?: project.findProperty("XCODE_SDK_NAME") as? String ?: "iphonesimulator"
+    val iOSTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
+        if (iOSTargetName.startsWith("iphoneos"))
+            ::iosArm64
+        else
+            ::iosX64
+    iOSTarget("ios") {
         binaries {
             framework {
                 baseName = iosFrameworkName
@@ -134,6 +153,20 @@ publishing {
     }
 }
 
+val packForXcode by tasks.creating(Sync::class) {
+    group = "build"
+    val mode = System.getenv("CONFIGURATION") ?: project.findProperty("XCODE_CONFIGURATION") as? String ?: "DEBUG"
+    //val sdkName = System.getenv("SDK_NAME") ?: project.findProperty("XCODE_SDK_NAME") as? String ?: "iphonesimulator"
+    val targetName = "ios" //+ if (sdkName.startsWith("iphoneos")) "Arm64" else "X64"
+    val framework = kotlin.targets.getByName<KotlinNativeTarget>(targetName).binaries.getFramework(mode)
+    inputs.property("mode", mode)
+    dependsOn(framework.linkTask)
+    val targetDir = File(buildDir, "xcode-frameworks")
+    from({ framework.outputDirectory })
+    into(targetDir)
+}
+tasks.getByName("build").dependsOn(packForXcode)
+
 //region XcFramework tasks
 val xcFrameworkPath = "build/xcframework/$iosFrameworkName.xcframework"
 val swiftPMPath = "${project.rootDir}/SwiftPackage/Binaries/$iosFrameworkName.xcframework"
@@ -150,7 +183,7 @@ val buildXcFramework by tasks.registering {
     }
     group = "build"
     val defaultMode = if (isSwiftPM) "RELEASE" else "DEBUG"
-    val mode = System.getenv("CONFIGURATION") ?: project.findProperty("XCODE_CONFIGURATION") as? String ?: defaultMode
+    val mode = project.findProperty("XCODE_CONFIGURATION") as? String ?: defaultMode
     val frameworks = arrayOf("iosArm64", "iosX64")
         .map { kotlin.targets.getByName<KotlinNativeTarget>(it).binaries.getFramework(mode) }
     inputs.property("mode", mode)

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -275,7 +275,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
 			buildPhases = (
-				7555FFB5242A651A00829871 /* ShellScript */,
 				7555FF77242A565900829871 /* Sources */,
 				7555FF78242A565900829871 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
@@ -406,26 +405,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		7555FFB5242A651A00829871 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :bridge-client:buildXcFramework -PXCODE_CONFIGURATION=${CONFIGURATION}\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		7555FF77242A565900829871 /* Sources */ = {

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -5,6 +5,15 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Type a script or drag a script file from your workspace to insert its path.&#10;cd &quot;$SRCROOT/..&quot;&#10;./gradlew :bridge-client:buildXcFramework  -PXCFRAMEWORK=&quot;true&quot; -PXCODE_CONFIGURATION=${CONFIGURATION}&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/xcframework_build.sh
+++ b/xcframework_build.sh
@@ -4,5 +4,4 @@
 #  iosApp
 # 
 
-./gradlew :bridge-client:buildXcFramework -PSWIFT_PM="true"
-
+./gradlew :bridge-client:buildXcFramework -PXCFRAMEWORK="true" -PSWIFT_PM="true" 


### PR DESCRIPTION
I’m not sure why the iOS framework is built as a part of building for Android, but this work-around allows the Android build to run.

I also updated the build script for running the iosApp project.