### PR TITLE
Added scroll buttons to the scrollview for the Today and History views

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/Views/Components/CustomScrollView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Views/Components/CustomScrollView.swift
@@ -160,8 +160,8 @@ public struct CustomScrollView<Content : View>: View {
             // Figure out how many pages are needed.
             let pageCount = Int(ceil(scrollHeight/viewHeight))
             if pages.count > 0 {
-                // Lop off the end. If there are more pages that there are currently
-                // then doing do will refresh the last page with a new height by
+                // Lop off the end. If there are more pages than there are currently
+                // then doing so will refresh the last page with a new height by
                 // replacing the UUID that is used as the identifier.
                 pages = Array(pages[0..<(min(pageCount, pages.count) - 1)])
             }

--- a/SwiftPackage/Sources/BridgeClientUI/Views/Components/CustomScrollView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Views/Components/CustomScrollView.swift
@@ -1,0 +1,250 @@
+//
+//  CustomScrollView.swift
+//
+//  Copyright © 2021 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import SwiftUI
+import SharedMobileUI
+
+public struct CustomScrollView<Content : View>: View {
+    private let content: Content
+    @StateObject private var viewModel: ViewModel = .init()
+
+    public init(_ content: @escaping () -> Content) {
+        self.content = content()
+    }
+    
+    public var body: some View {
+        ContentView(height: $viewModel.viewHeight) {
+            ScrollViewReader { scrollView in
+                ZStack(alignment: .bottomTrailing) {
+                    
+                    ScrollView(.vertical) {
+                        ZStack(alignment: .top) {
+                            GeometryReader { proxy in
+                                Color.clear
+                                    .preference(key: ScrollFramePreferenceKey.self,
+                                                value: proxy.frame(in: .named("scroll")))
+                            }
+                            makePageMarkers()
+                            ContentView(height: $viewModel.scrollHeight) {
+                                content
+                            }
+                        }
+                    }
+                    .coordinateSpace(name: "scroll")
+                    .frame(maxWidth: .infinity)
+                    .onPreferenceChange(ScrollFramePreferenceKey.self) { value in
+                        viewModel.scrollOffset = abs(floor(value.minY))
+                    }
+                    
+                    makeButtons(scrollView: scrollView)
+
+                } // end ZStack (for overlay buttons)
+            }// end ScrollViewReader
+        }
+    }// end body
+    
+    @ViewBuilder
+    private func makeButtons(scrollView: ScrollViewProxy) -> some View {
+        VStack(alignment: .trailing, spacing: 13) {
+            Button("Scroll Up", bundle: .module) {
+                viewModel.scrollUp(scrollView)
+            }
+            .buttonStyle(ScrollButtonStyle(up: true, enabled: $viewModel.upEnabled))
+            
+            Button("Scroll Down", bundle: .module) {
+                viewModel.scrollDown(scrollView)
+            }
+            .buttonStyle(ScrollButtonStyle(up: false, enabled: $viewModel.downEnabled))
+        }
+        .opacity(viewModel.scrollEnabled ? 1 : 0)
+        .padding(.trailing, 9)
+        .padding(.bottom, 16)
+    }
+    
+    @ViewBuilder
+    private func makePageMarkers() -> some View {
+        LazyVStack(spacing: 0) {
+            ForEach(viewModel.pages) { page in
+                Color.clear
+                    .frame(height: viewModel.height(for: page))
+            }
+        }
+    }
+    
+    struct Placeholder : Identifiable, Hashable {
+        let id: UUID = .init()
+    }
+    
+    class ViewModel : ObservableObject {
+        @Published var pages: [Placeholder] = []
+        @Published var upEnabled: Bool = true
+        @Published var downEnabled: Bool = true
+        @Published var scrollEnabled: Bool = true
+        
+        @Published var scrollOffset: CGFloat = 0 {
+            didSet {
+                upEnabled = scrollOffset > 10
+                downEnabled = scrollHeight - (scrollOffset + viewHeight) > 10 || (round(scrollOffset) == 0)
+            }
+        }
+        
+        @Published var viewHeight: CGFloat = 0 {
+            didSet {
+                updatePages()
+            }
+        }
+        
+        @Published var scrollHeight: CGFloat = 0 {
+            didSet {
+                updatePages()
+            }
+        }
+        
+        func height(for page: Placeholder) -> CGFloat {
+            page == pages.last
+                ? (scrollHeight - (CGFloat(pages.count - 1) * viewHeight))
+                : viewHeight
+        }
+        
+        func scrollUp(_ scrollView: ScrollViewProxy) {
+            let normalizedOffset = scrollOffset / viewHeight
+            let currentIndex = Int(ceil(normalizedOffset))
+            let index = max(currentIndex - 1, 0)
+            scrollView.scrollTo(pages[index].id, anchor: .top)
+        }
+        
+        func scrollDown(_ scrollView: ScrollViewProxy) {
+            let normalizedOffset = scrollOffset / viewHeight
+            let currentIndex = Int(round(normalizedOffset))
+            let index = min(currentIndex + 1, pages.count - 1)
+            scrollView.scrollTo(pages[index].id, anchor: .bottom)
+        }
+        
+        private func updatePages() {
+            scrollEnabled = scrollHeight > viewHeight
+            guard scrollHeight > 0, viewHeight > 0, scrollEnabled
+            else {
+                // Do not load any pages if the view is longer than the content.
+                self.pages = []
+                return
+            }
+            // Figure out how many pages are needed.
+            let pageCount = Int(ceil(scrollHeight/viewHeight))
+            if pages.count > 0 {
+                // Lop off the end. If there are more pages that there are currently
+                // then doing do will refresh the last page with a new height by
+                // replacing the UUID that is used as the identifier.
+                pages = Array(pages[0..<(min(pageCount, pages.count) - 1)])
+            }
+            // Finally, add pages until the counts match.
+            // Note: syoung 08/18/2021 The view crashes if you do not add one at a time.
+            while pages.count < pageCount {
+                pages.append(.init())
+            }
+        }
+    }
+    
+    struct ContentView<Content : View>: View {
+        private let content: Content
+        @Binding private var contentHeight: CGFloat
+        
+        public init(height: Binding<CGFloat>, _ content: @escaping () -> Content) {
+            self._contentHeight = height
+            self.content = content()
+        }
+        
+        var body: some View {
+            ZStack {
+                content
+            }
+            .background(GeometryReader { proxy in
+                Color.clear
+                    .preference(key: ViewHeightPreferenceKey.self,
+                                value: proxy.size.height)
+            })
+            .onPreferenceChange(ViewHeightPreferenceKey.self) { value in
+                guard contentHeight != floor(value) else { return }
+                contentHeight = floor(value)
+            }
+        }
+    }
+
+    struct ScrollButtonStyle : ButtonStyle {
+        let up: Bool
+        @Binding var enabled: Bool
+        
+        @ViewBuilder
+        func makeBody(configuration: Self.Configuration) -> some View {
+            VStack {
+                if up {
+                    Image(systemName: "arrow.up")
+                }
+                Text("scroll", bundle: .module)
+                    .font(.latoFont(10, relativeTo: nil, weight: .regular))
+                if !up {
+                    Image(systemName: "arrow.down")
+                }
+            }
+            .opacity(enabled ? 1 : 0.3)
+            .foregroundColor(.textForeground)
+            .frame(width: 48, height: 48)
+            .background(enabled ? Color.accentColor : Color.hexDEDEDE)
+            .clipShape(Capsule())
+            .shadow(color: .sageBlack.opacity(0.25), radius: 4, x: 0, y: 4)
+            .opacity((enabled || !up) ? 1 : 0)
+        }
+    }
+}
+
+fileprivate struct ScrollFramePreferenceKey: PreferenceKey {
+    static var defaultValue: CGRect = .zero
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {}
+}
+
+fileprivate struct ViewHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = .zero
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {}
+}
+
+extension Button where Label == Text {
+    init(_ titleKey: LocalizedStringKey, bundle: Bundle?, action: @escaping () -> Void) {
+        self.init(action: action, label: { Text(titleKey, bundle: bundle) })
+    }
+}
+
+// syoung 08/16/2021 SwiftUI fails to build complex UI in a shared framework. Therefore, the preview
+// for this element is in iosApp.
+struct CustomScrollView_Previews: PreviewProvider {
+    static var previews: some View {
+        Text("Hello, World")
+    }
+}

--- a/SwiftPackage/Sources/BridgeClientUI/Views/HistoryView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Views/HistoryView.swift
@@ -49,7 +49,7 @@ public struct HistoryView: View {
         ScreenBackground {
             VStack(spacing: 21) {
                 header()
-                ScrollView {
+                CustomScrollView {
                     LazyVStack(spacing: 16) {
                         ForEach(viewModel.records) { record in
                             card(record)

--- a/SwiftPackage/Sources/BridgeClientUI/Views/TodayView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Views/TodayView.swift
@@ -47,7 +47,7 @@ public struct TodayView: View {
         ScreenBackground {
             VStack {
                 dateHeader()
-                ScrollView {
+                CustomScrollView {
                     LazyVStack(spacing: 16) {
                         ForEach(TodayTimelineSession.SessionState.allCases, id: \.rawValue) { state in
                             let sessions = viewModel.filterSchedules(for: state)

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		FF8C11EE26CB364B00A9AE72 /* PreviewEndOfStudyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8C11ED26CB364B00A9AE72 /* PreviewEndOfStudyView.swift */; };
 		FF8C11F026CB3BC300A9AE72 /* PreviewPrivacyNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8C11EF26CB3BC300A9AE72 /* PreviewPrivacyNoticeView.swift */; };
 		FFE2DF6926CACD3C00DD1E7B /* PreviewCustomTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE2DF6826CACD3C00DD1E7B /* PreviewCustomTabView.swift */; };
+		FFE3F34426CC860A009614D5 /* PreviewCustomScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE3F34326CC860A009614D5 /* PreviewCustomScrollView.swift */; };
 		FFFE875F26CAF9B000274002 /* PreviewHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFE875E26CAF9B000274002 /* PreviewHistoryView.swift */; };
 /* End PBXBuildFile section */
 
@@ -64,6 +65,7 @@
 		FF8C11ED26CB364B00A9AE72 /* PreviewEndOfStudyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewEndOfStudyView.swift; sourceTree = "<group>"; };
 		FF8C11EF26CB3BC300A9AE72 /* PreviewPrivacyNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewPrivacyNoticeView.swift; sourceTree = "<group>"; };
 		FFE2DF6826CACD3C00DD1E7B /* PreviewCustomTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCustomTabView.swift; sourceTree = "<group>"; };
+		FFE3F34326CC860A009614D5 /* PreviewCustomScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCustomScrollView.swift; sourceTree = "<group>"; };
 		FFFE875E26CAF9B000274002 /* PreviewHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHistoryView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -140,6 +142,7 @@
 				FF8C11ED26CB364B00A9AE72 /* PreviewEndOfStudyView.swift */,
 				FF8C11EF26CB3BC300A9AE72 /* PreviewPrivacyNoticeView.swift */,
 				FF0B930026CC3DAE0041A486 /* PreviewStudyInfoView.swift */,
+				FFE3F34326CC860A009614D5 /* PreviewCustomScrollView.swift */,
 			);
 			path = "Preview Content";
 			sourceTree = "<group>";
@@ -311,6 +314,7 @@
 				7555FF7F242A565900829871 /* AppDelegate.swift in Sources */,
 				7555FF81242A565900829871 /* SceneDelegate.swift in Sources */,
 				FF7ED30226A89739001F9E8B /* ExternalIdLoginView.swift in Sources */,
+				FFE3F34426CC860A009614D5 /* PreviewCustomScrollView.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				FFFE875F26CAF9B000274002 /* PreviewHistoryView.swift in Sources */,
 				FFE2DF6926CACD3C00DD1E7B /* PreviewCustomTabView.swift in Sources */,

--- a/iosApp/iosApp/Preview Content/PreviewCustomScrollView.swift
+++ b/iosApp/iosApp/Preview Content/PreviewCustomScrollView.swift
@@ -1,0 +1,59 @@
+//
+//  PreviewCustomScrollView.swift
+//
+//  Copyright © 2021 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import SwiftUI
+import BridgeClientUI
+
+struct PreviewCustomScrollView: View {
+    @State var items: [Item] = [Int](0..<100).map { .init(id: "\($0) Hello, World") }
+    var body: some View {
+        CustomScrollView {
+            LazyVStack {
+                ForEach(items) { item in
+                    Button(item.id) {
+                        items.remove(where: { $0 == item})
+                    }
+                }
+            }
+        }
+    }
+    
+    struct Item : Identifiable, Hashable {
+        let id: String
+    }
+}
+
+struct PreviewCustomScrollView_Previews: PreviewProvider {
+    static var previews: some View {
+        PreviewCustomScrollView()
+    }
+}


### PR DESCRIPTION
I have some concerns that for the history view with several pages this could seriously affect scrolling performance. I don't have enough experience with SwiftUI and `LazyVStack` to be able to say with confidence. In other words, I *think* using UUID's (instead of Int) as the page identifiers will allow for rendering only those views that are in the scroll window (even though height is calculated on the fly) but I'm not sure about paging for longer scroll windows.