### PR TITLE
Add @Serializable to ScheduledNotification data class

### DIFF
--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/ScheduleTimelineRepo.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/ScheduleTimelineRepo.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.datetime.*
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.sagebionetworks.bridge.kmm.shared.apis.SchedulesV2Api
@@ -549,6 +550,7 @@ data class ScheduledAssessmentReference (
     }
 }
 
+@Serializable
 data class ScheduledNotification(
     val instanceGuid: String,
     val scheduleOn: LocalDateTime,


### PR DESCRIPTION
This makes it easier to pass the notification data around when scheduling notifications on Android.