### PR TITLE
Fix android studios

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/Views/Components/CustomScrollView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Views/Components/CustomScrollView.swift
@@ -62,7 +62,12 @@ public struct CustomScrollView<Content : View>: View {
                     .coordinateSpace(name: "scroll")
                     .frame(maxWidth: .infinity)
                     .onPreferenceChange(ScrollFramePreferenceKey.self) { value in
-                        viewModel.scrollOffset = abs(floor(value.minY))
+                        // syoung 09/09/2021 So... it turns out that this isn't always called
+                        // on the main thread so it was getting updated multiple times per
+                        // frame.
+                        DispatchQueue.main.async {
+                            viewModel.scrollOffset = abs(floor(value.minY))
+                        }
                     }
                     
                     makeButtons(scrollView: scrollView)
@@ -192,8 +197,10 @@ public struct CustomScrollView<Content : View>: View {
                                 value: proxy.size.height)
             })
             .onPreferenceChange(ViewHeightPreferenceKey.self) { value in
-                guard contentHeight != floor(value) else { return }
-                contentHeight = floor(value)
+                DispatchQueue.main.async {
+                    guard contentHeight != floor(value) else { return }
+                    contentHeight = floor(value)
+                }
             }
         }
     }

--- a/bridge-client/build.gradle.kts
+++ b/bridge-client/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     id("com.android.library")
@@ -27,33 +28,24 @@ kotlin {
         publishAllLibraryVariants()
     }
 
-    // This bit is here to build the XCFramework. syoung 07/02/21
+    // syoung 09/13/2021 If this is building for XCFramework, then build both
+    // binaries, otherwise, just build for simulator.
+    // https://github.com/cashapp/sqldelight/issues/2044#issuecomment-721299517.
     if (project.findProperty("XCFRAMEWORK") == "true") {
         ios {
             binaries {
                 framework {
                     baseName = iosFrameworkName
-                    // Include DSYM in the release build
-                    freeCompilerArgs += "-Xg0"
-                    // Include Generics in the module header.
-                    freeCompilerArgs += "-Xobjc-generics"
                 }
             }
         }
     }
-
-    // This bit is here so that running `./gradlew build` will work. syoung 07/02/21
-    // Block from https://github.com/cashapp/sqldelight/issues/2044#issuecomment-721299517.
-    val iOSTargetName  = System.getenv("SDK_NAME") ?: project.findProperty("XCODE_SDK_NAME") as? String ?: "iphonesimulator"
-    val iOSTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        if (iOSTargetName.startsWith("iphoneos"))
-            ::iosArm64
-        else
-            ::iosX64
-    iOSTarget("ios") {
-        binaries {
-            framework {
-                baseName = iosFrameworkName
+    else {
+        iosX64("ios") {
+            binaries {
+                framework {
+                    baseName = iosFrameworkName
+                }
             }
         }
     }
@@ -157,45 +149,23 @@ publishing {
     }
 }
 
-val packForXcode by tasks.creating(Sync::class) {
-    group = "build"
-    val mode = System.getenv("CONFIGURATION") ?: project.findProperty("XCODE_CONFIGURATION") as? String ?: "DEBUG"
-    //val sdkName = System.getenv("SDK_NAME") ?: project.findProperty("XCODE_SDK_NAME") as? String ?: "iphonesimulator"
-    val targetName = "ios" //+ if (sdkName.startsWith("iphoneos")) "Arm64" else "X64"
-    val framework = kotlin.targets.getByName<KotlinNativeTarget>(targetName).binaries.getFramework(mode)
-    inputs.property("mode", mode)
-    dependsOn(framework.linkTask)
-    val targetDir = File(buildDir, "xcode-frameworks")
-    from({ framework.outputDirectory })
-    into(targetDir)
-}
-tasks.getByName("build").dependsOn(packForXcode)
-
 //region XcFramework tasks
-val xcFrameworkPath = "build/xcframework/$iosFrameworkName.xcframework"
 val swiftPMPath = "${project.rootDir}/SwiftPackage/Binaries/$iosFrameworkName.xcframework"
 
 tasks.create<Delete>("deleteSwiftPMFramework") { delete = setOf(swiftPMPath) }
-tasks.create<Delete>("deleteXcFramework") { delete = setOf(xcFrameworkPath) }
 
 val buildXcFramework by tasks.registering {
-    val isSwiftPM = (project.findProperty("SWIFT_PM") == "true")
-    if (isSwiftPM) {
-        dependsOn("deleteSwiftPMFramework")
-    } else {
-        dependsOn("deleteXcFramework")
-    }
+    dependsOn("deleteSwiftPMFramework")
     group = "build"
-    val defaultMode = if (isSwiftPM) "RELEASE" else "DEBUG"
-    val mode = project.findProperty("XCODE_CONFIGURATION") as? String ?: defaultMode
+    val mode = project.findProperty("XCODE_CONFIGURATION") as? String ?: "RELEASE"
     val frameworks = arrayOf("iosArm64", "iosX64")
         .map { kotlin.targets.getByName<KotlinNativeTarget>(it).binaries.getFramework(mode) }
     inputs.property("mode", mode)
     dependsOn(frameworks.map { it.linkTask })
-    doLast { buildXcFramework(frameworks, isSwiftPM) }
+    doLast { buildXcFramework(frameworks) }
 }
 
-fun buildXcFramework(frameworks: List<Framework>, isSwiftPM: Boolean) {
+fun buildXcFramework(frameworks: List<Framework>) {
     val buildArgs: () -> List<String> = {
         val arguments = mutableListOf("-create-xcframework")
         frameworks.forEach {
@@ -205,7 +175,7 @@ fun buildXcFramework(frameworks: List<Framework>, isSwiftPM: Boolean) {
             arguments += "${it.outputDirectory}/${it.baseName}.framework.dSYM"
         }
         arguments += "-output"
-        arguments += if (isSwiftPM) swiftPMPath else xcFrameworkPath
+        arguments += swiftPMPath
         arguments
     }
     exec {

--- a/bridge-client/src/iosMain/kotlin/org/sagebionetworks/bridge/kmm/shared/JsonElementCodable.kt
+++ b/bridge-client/src/iosMain/kotlin/org/sagebionetworks/bridge/kmm/shared/JsonElementCodable.kt
@@ -7,6 +7,7 @@ import platform.Foundation.*
 import org.sagebionetworks.bridge.kmm.shared.models.*
 import org.sagebionetworks.bridge.mpp.network.generated.models.AppConfig
 
+// TODO: syoung 09/08/2021 Deprecate this class and use Generic JsonDecoder below
 class JsonElementDecoder(private val jsonData: NSData) {
     @Throws(Throwable::class)
     fun decodeObject(): JsonElement {


### PR DESCRIPTION
This runs `check`, `build`, and the script for building the xcframework for the swift package (debug and release).

Note: I did *not* use the XCFramework() gradle build that Kotlin uses b/c that doesn't put it in the correct location for the swift package and I can't figure out how to copy it there - didn't seem worth the time to figure it out since I was already building it where I want it to go. ¯\_(ツ)_/¯ 