### PR TITLE
Fix loading study

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/BridgeClientAppManager.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/BridgeClientAppManager.swift
@@ -137,7 +137,7 @@ open class BridgeClientAppManager : ObservableObject {
         userSessionInfo = nil
     }
     
-    private func updateAppState() {
+    func updateAppState() {
         if appConfig == nil {
             appState = .launching
         }

--- a/SwiftPackage/Sources/BridgeClientUI/SingleStudyAppManager.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/SingleStudyAppManager.swift
@@ -72,6 +72,8 @@ public final class SingleStudyAppManager : BridgeClientAppManager {
         try? studyManager?.onCleared()
         studyManager = nil
         study = nil
+        studyId = nil
+        observedStudyId = nil
         super.signOut()
     }
     


### PR DESCRIPTION
### BMC-219: Use the appState to show launching while loading the study
For whatever reason, iOS 14.4 is not recognizing the changes to the published Study
object. This is the only case where a Kotlin model object is used referenced directly
within SwiftUI. This changes the updateAppState() method to use that to set the
`appState` to `.launching` if the Study is being loaded.

### BMC-218: Logout hangs on loading study 
B/c of how login depends upon the studyId *before* I have all the information about the study
(which is not available to an unauthenticated user), there are a bunch of things that need to be
nil'd out when logging out. Missed some of the ivars.