### PR TITLE
Show a preview of the PolicyNotice PDF

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/Views/PrivacyNoticeView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Views/PrivacyNoticeView.swift
@@ -174,15 +174,16 @@ struct DocumentPreview: UIViewControllerRepresentable {
         }
     }
 
-    func makeCoordinator() -> Coordintor {
-        return Coordintor(owner: self)
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(owner: self)
     }
 
-    final class Coordintor: NSObject, UIDocumentInteractionControllerDelegate { // works as delegate
+    final class Coordinator: NSObject, UIDocumentInteractionControllerDelegate { // works as delegate
         let owner: DocumentPreview
         init(owner: DocumentPreview) {
             self.owner = owner
         }
+        
         func documentInteractionControllerViewControllerForPreview(_ controller: UIDocumentInteractionController) -> UIViewController {
             return owner.viewController
         }


### PR DESCRIPTION
Showing the share sheet for sharing the PDF is mad slow and
can take *several* seconds to load. This is a work-around
intended to show a preview of the PDF document and gives
the participant the option to print, save to file, air drop, etc.

While this does mean a lot of tapping. Tap to dismiss share then
tap again to dismiss preview, the trade-off is that it loads
**WAY** faster.