### PR TITLE
MTB-336 Set "declined" to true if abandoned

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/Models/SageResearchTaskDelegate.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Models/SageResearchTaskDelegate.swift
@@ -77,8 +77,8 @@ open class SageResearchTaskDelegate : NSObject, RSDTaskViewControllerDelegate {
         
         let taskResult = taskController.taskViewModel.taskResult
         let clientData = (taskController.task as? RSDTrackingTask)?.taskData(for: taskResult)?.json
-        let endedOn = (reason == .completed) ? taskResult.endDate : nil
-        let declined = (reason == .earlyExit)
+        let declined = taskController.taskViewModel.didAbandon
+        let endedOn = (reason == .completed) && !declined ? taskResult.endDate : nil
         
         assessmentManager.updateAdherenceRecord(scheduleInfo: scheduledAssessment,
                                    startedOn: taskResult.startDate,


### PR DESCRIPTION
Apparently, the meaning of "declined" should map to "didAbandon" rather than "early exit" (which means they want to finish later, I guess...) and the task end date should only be set if completed *and* not abandoned. *sigh*