### PR TITLE
Gradle and library updates to work with Android Mobile Toolbox App

### DIFF
--- a/bridge-client/src/androidMain/AndroidManifest.xml
+++ b/bridge-client/src/androidMain/AndroidManifest.xml
@@ -5,8 +5,15 @@
     <application>
         <!-- Using Koin to initialize WorkManager, need to remove default initializer       -->
         <provider
-            android:name="androidx.work.impl.WorkManagerInitializer"
-            android:authorities="${applicationId}.workmanager-init"
-            tools:node="remove" />
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <!-- If you are using androidx.startup to initialize other components -->
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 </manifest>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
-        classpath("com.android.tools.build:gradle:7.0.3")
+        classpath("com.android.tools.build:gradle:7.1.3")
         classpath("com.squareup.sqldelight:gradle-plugin:${Versions.sqlDelight}")
         classpath("org.jetbrains.kotlin:kotlin-serialization:${Versions.kotlin}")
         classpath("dev.icerock.moko:network-generator:0.16.0")

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val min_sdk = 23
-    const val target_sdk = 31
-    const val compile_sdk = 31
+    const val target_sdk = 30
+    const val compile_sdk = 30
 
     //Kotlin
     const val kotlin = "1.5.30"
@@ -25,7 +25,7 @@ object Versions {
         val recyclerview = "1.1.0"
         val test = "1.3.0"
         val test_ext = "1.1.2"
-        val workManager = "2.5.0"
+        val workManager = "2.6.0"
     }
 
     const val slf4j = "1.7.30"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
We can't target Android version 31 until Northwestern updates their measures.
Updating WorkManager library so it works with updates in MTB app