### PR TITLE
BridgeFileUploadManager keeps isUploading status flag up-to-date

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/BridgeClientAppManager.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/BridgeClientAppManager.swift
@@ -122,9 +122,8 @@ open class BridgeClientAppManager : ObservableObject {
     /// The "state" of the app.
     @Published public var appState: AppState = .launching
     
-    /// Is the app currently uploading results?
-    /// TODO: syoung 10/27/2021 This flag is currently never being reset. https://sagebionetworks.jira.com/browse/BMC-244
-    @Published public var isUploadingResults: Bool = false
+    /// Is the app currently uploading results or user files? This status is maintained and updated by BridgeFileUploadManager.
+    @Published public var isUploading: Bool = false
     
     /// A threadsafe observer for the `BridgeClient.UserSessionInfo` for the current user.
     public let appConfig: AppConfigObserver = .init()
@@ -303,7 +302,6 @@ open class BridgeClientAppManager : ObservableObject {
             }
 
             DispatchQueue.main.async {
-                self.isUploadingResults = true
                 archives.forEach { archive in
                     var exporterV3Metadata: JsonElement? = nil
                     if let schedule = (archive as? AbstractResultArchive)?.schedule {

--- a/SwiftPackage/Sources/BridgeClientUI/File Uploading/StudyDataUploadAPI.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/File Uploading/StudyDataUploadAPI.swift
@@ -290,7 +290,8 @@ public class StudyDataUploadAPI: BridgeFileUploadAPITyped {
         do {
             uploadMetadata.bridgeUploadTrackingObject.uploadSession = try self.uploadManager.netManager.jsonDecoder.decode(UploadRequestResponseType.self, from: jsonData)
         } catch let err {
-            debugPrint("Unexpected: Could not parse contents of downloaded file as a \(UploadRequestResponseType.self) object: \"\(String(describing: String(data: jsonData, encoding: .utf8)))\"\n\terror:\(err)")
+            // it's not an upload request response so log it (just in case it's something unexpected) and return nil
+            debugPrint("Could not parse contents of downloaded file as a \(UploadRequestResponseType.self) object, ignoring: \"\(String(describing: String(data: jsonData, encoding: .utf8)))\"\n\terror:\(err)")
             return nil
         }
         return uploadMetadata

--- a/SwiftPackage/Sources/BridgeClientUI/SingleStudy/Views/EndOfStudyView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/SingleStudy/Views/EndOfStudyView.swift
@@ -53,7 +53,7 @@ public struct EndOfStudyView: View {
     
     public var body: some View {
         ScreenBackground {
-            if bridgeManager.isUploadingResults {
+            if bridgeManager.isUploading {
                 waitMessage
             }
             else {

--- a/SwiftPackage/Tests/BridgeClientUITests/BridgeFileUploadManagerTestCase.swift
+++ b/SwiftPackage/Tests/BridgeClientUITests/BridgeFileUploadManagerTestCase.swift
@@ -322,7 +322,7 @@ extension BridgeFileUploadManagerTestCaseTyped {
         }
         
         // -- wait here until everything above has worked its way through.
-        XCTWaiter(delegate: self).wait(for: [expectRetried], timeout: 500.0)
+        XCTWaiter(delegate: self).wait(for: [expectRetried], timeout: 5.0)
         NotificationCenter.default.removeObserver(observer503Retried)
         NotificationCenter.default.removeObserver(observer503NotRetried)
         NotificationCenter.default.removeObserver(observer503RetriedButS3Failed)

--- a/SwiftPackage/Tests/BridgeClientUITests/MockURLSession.swift
+++ b/SwiftPackage/Tests/BridgeClientUITests/MockURLSession.swift
@@ -309,5 +309,11 @@ class MockURLSession: URLSession {
         add(mockTask: task)
         return task
     }
+    
+    override func getAllTasks(completionHandler: @escaping ([URLSessionTask]) -> Void) {
+        self.delegateQueue.addOperation {
+            completionHandler(self.mockTasks as? [URLSessionTask] ?? [])
+        }
+    }
 }
 

--- a/SwiftPackage/Tests/BridgeClientUITests/Resources/pf-upload-request-success.json
+++ b/SwiftPackage/Tests/BridgeClientUITests/Resources/pf-upload-request-success.json
@@ -2,5 +2,6 @@
     "fileId":"TestFileId",
     "mimeType": "image/jpeg",
     "uploadUrl":"/not-a-real-pre-signed-S3-url",
+    "expiresOn":"2999-12-31T11:59:59.999Z",
     "type":"ParticipantFile"
 }

--- a/SwiftPackage/Tests/BridgeClientUITests/Resources/upload-complete-response.json
+++ b/SwiftPackage/Tests/BridgeClientUITests/Resources/upload-complete-response.json
@@ -1,0 +1,4 @@
+{
+    "status":"validation_in_progress",
+    "type":"UploadValidationStatus"
+}


### PR DESCRIPTION
…so that it can be used for accurate participant  feedback regarding the progress of result and participant file uploads.