### PR TITLE
DHP-60

### DIFF
--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/cache/ResourceDatabaseHelper.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/cache/ResourceDatabaseHelper.kt
@@ -55,7 +55,7 @@ class ResourceDatabaseHelper(sqlDriver: SqlDriver) : EtagStorageCache {
         return dbQuery.selectResourceById(id, type, studyId).asFlow().mapToOneOrNull().distinctUntilChanged(areEquivalent = {old, new -> old == new })
     }
 
-    internal fun getResource(id: String, type: ResourceType, studyId: String): Resource? {
+    fun getResource(id: String, type: ResourceType, studyId: String): Resource? {
         return dbQuery.selectResourceById(id, type, studyId).executeAsOneOrNull()
     }
 
@@ -67,7 +67,7 @@ class ResourceDatabaseHelper(sqlDriver: SqlDriver) : EtagStorageCache {
         dbQuery.removeResourceById(id, type, studyId)
     }
 
-    internal fun insertUpdateResource(resource: Resource) {
+    fun insertUpdateResource(resource: Resource) {
         dbQuery.transaction {
             dbQuery.insertUpdateResource(
                 identifier = resource.identifier,

--- a/bridge-client/src/iosMain/kotlin/org/sagebionetworks/bridge/kmm/shared/NativeTimelineManager.kt
+++ b/bridge-client/src/iosMain/kotlin/org/sagebionetworks/bridge/kmm/shared/NativeTimelineManager.kt
@@ -21,11 +21,11 @@ class NativeTimelineManager(
     private val viewUpdate: (NativeScheduledSessionTimelineSlice) -> Unit
 ) : KoinComponent {
 
-    private val repo : ScheduleTimelineRepo by inject(mode = LazyThreadSafetyMode.NONE)
-    private val assessmentConfigRepo : AssessmentConfigRepo by inject(mode = LazyThreadSafetyMode.NONE)
-    private val localCache : LocalJsonDataCache by inject(mode = LazyThreadSafetyMode.NONE)
-    private val adherenceRecordRepo : AdherenceRecordRepo by inject(mode = LazyThreadSafetyMode.NONE)
-    private val activityEventsRepo : ActivityEventsRepo by inject(mode = LazyThreadSafetyMode.NONE)
+    val repo : ScheduleTimelineRepo by inject(mode = LazyThreadSafetyMode.NONE)
+    val assessmentConfigRepo : AssessmentConfigRepo by inject(mode = LazyThreadSafetyMode.NONE)
+    val localCache : LocalJsonDataCache by inject(mode = LazyThreadSafetyMode.NONE)
+    val adherenceRecordRepo : AdherenceRecordRepo by inject(mode = LazyThreadSafetyMode.NONE)
+    val activityEventsRepo : ActivityEventsRepo by inject(mode = LazyThreadSafetyMode.NONE)
 
     private val scope = MainScope()
 


### PR DESCRIPTION
Exposes ResourceDatabase read/write functions.

I could see the argument for keeping these functions internal, but this is the easiest way to complete this Jira issue below when the user is without internet.

The DIAN app will read the ParticipantSchedule resource, re-run the schedule mutator with different randomized start times, and then write the ParticipantSchedule after.

 https://sagebionetworks.jira.com/browse/DHP-60 
 
 