### PR TITLE
Fix app archiving

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/Assessment Handling/AssessmentInfoMap.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Assessment Handling/AssessmentInfoMap.swift
@@ -118,7 +118,7 @@ extension BridgeClient.AssessmentInfo {
     fileprivate var assessmentId: String { identifier }
     fileprivate var iconKey: SageResourceImage.Name {
         // TODO: syoung 05/19/2022 Support getting the resource image key from the AssessmentInfo object.
-        .survey
+        SageResourceImage.Name.allCases.first!
     }
 }
 


### PR DESCRIPTION
This changes the initial firing of the async operation to archive, encrypt, and upload files into an internal class that is called from the UploadAppManager.

Under an unknown set of circumstances, Xcode was failing to archive an app for publication to the App Store (or TestFlight). I was unable to riddle out why it fails for archiving MTB and DIAN where it worked for BiAffect. It is likely somewhere in the build settings for those apps but I couldn't find anything explaining the issue and a solution. My suspicion is that there is something in the async/await and use of MainActor that doesn't play nicely with inheritance across different Swift libraries.

That said, I wanted to unblock @dephillipsmichael so I'm asking for this work-around to be accepted (since it works to archive the MTB app and will hopefully work for DIAN) while I continue testing of this issue to see if I can develop a simpler repro that can be used to file a radar. ¯\_(ツ)_/¯  
