### PR TITLE
Clear user defaults and temp files as part of unit test setup

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,6 +13,6 @@ jobs:
     - name: Repository checkout
       uses: actions/checkout@v2
     - name: Build for iOS
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -scheme BridgeClient-Package -destination "platform=iOS Simulator,OS=16.0,name=iPhone 12" | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -scheme BridgeClient-Package -destination "platform=iOS Simulator,OS=16.2,name=iPhone 14" | xcpretty
     - name: Run iOS tests
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -scheme BridgeClient-Package -destination "platform=iOS Simulator,OS=16.0,name=iPhone 12" | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -scheme BridgeClient-Package -destination "platform=iOS Simulator,OS=16.2,name=iPhone 14" | xcpretty

--- a/SwiftPackage/Tests/BridgeClientExtensionTests/BridgeFileUploadManagerTestCase.swift
+++ b/SwiftPackage/Tests/BridgeClientExtensionTests/BridgeFileUploadManagerTestCase.swift
@@ -58,6 +58,22 @@ extension BridgeFileUploadManagerTestCaseTyped {
         BackgroundNetworkManager.sessionDelegateQueue.addOperations([setMockSession], waitUntilFinished: true)
         savedDelay = BridgeFileUploadManager.shared.delayForRetry
         BridgeFileUploadManager.shared.delayForRetry = 0 // don't delay retries for tests
+        
+        // Clear user defaults - may have leftover cruft from previous failed test run
+        let bfum = BridgeFileUploadManager.shared
+        let defaults = bfum.userDefaults
+        defaults.set(nil, forKey: bfum.retryUploadsKey)
+        defaults.set(nil, forKey: bfum.bridgeFileUploadsKey)
+        defaults.set(nil, forKey: bfum.uploadURLsRequestedKey)
+        defaults.set(nil, forKey: bfum.uploadingToS3Key)
+        defaults.set(nil, forKey: bfum.notifyingBridgeUploadSucceededKey)
+        
+        // Remove all temp files - may have leftover cruft from previous failed test run
+        if let items = try? FileManager.default.contentsOfDirectory(at: self.uploadApi.tempUploadDirURL, includingPropertiesForKeys: nil, options: []) {
+            items.forEach {
+                try? FileManager.default.removeItem(at: $0)
+            }
+        }
     }
 
     func genericTearDown() {


### PR DESCRIPTION
Once unit tests fail, could not see if I’d fixed them b/c of leftover cruft from previous test run.