### PR TITLE
Add task to copy binary to Swift Package

### DIFF
--- a/bridge-client/build.gradle.kts
+++ b/bridge-client/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import com.android.zipflinger.Sources.dir
 import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
@@ -167,6 +168,21 @@ publishing {
                 username = System.getenv("artifactoryUser")
                 password = System.getenv("artifactoryPwd")
             }
+        }
+    }
+}
+
+
+
+tasks.register("createSwiftPackage") {
+    description = "Creates a Swift package to distribute an XCFramework"
+
+    dependsOn("assembleBridgeClientXCFramework")
+
+    doLast {
+        copy {
+            from(layout.buildDirectory.dir("XCFrameworks"))
+            into("$rootDir/SwiftPackage/Binaries/")
         }
     }
 }


### PR DESCRIPTION
I wasn't able to figure out how to get java running from the commandline, but I did figure out how to add a task to assemble the XCFramework and then copy the files to the Swift Package.