### PR TITLE
Add localization keys for all caps titles

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/Resources/en.lproj/Localizable.strings
+++ b/SwiftPackage/Sources/BridgeClientUI/Resources/en.lproj/Localizable.strings
@@ -1,17 +1,17 @@
-/* return Text("ABOUT THE STUDY", bundle: .module) */
-"ABOUT THE STUDY" = "ABOUT THE STUDY";
+/* return Text("ABOUT_THE_STUDY", bundle: .module) */
+"ABOUT_THE_STUDY" = "About the Study";
 
 /* Label("Back", systemImage: "arrow.left", bundle: .module) */
 "Back" = "Back";
 
-/* return Text("CONTACT & SUPPORT", bundle: .module) */
-"CONTACT & SUPPORT" = "CONTACT & SUPPORT";
+/* return Text("CONTACT_AND_SUPPORT", bundle: .module) */
+"CONTACT_AND_SUPPORT" = "Contact & Support";
 
 /* return Text("Completed", bundle: .module) */
 "Completed" = "Completed";
 
-/* return Text("Current activities", bundle: .module) */
-"Current activities" = "Current activities";
+/* return Text("CURRENT_ACTIVITIES", bundle: .module) */
+"CURRENT_ACTIVITIES" = "Current activities";
 
 /* Text("Done") */
 "Done" = "Done";

--- a/SwiftPackage/Sources/BridgeClientUI/SingleStudy/Views/StudyInfoView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/SingleStudy/Views/StudyInfoView.swift
@@ -22,9 +22,9 @@ public struct StudyInfoView: View {
         public func title() -> Text {
             switch self {
             case .about:
-                return Text("ABOUT THE STUDY", bundle: .module)
+                return Text("ABOUT_THE_STUDY", bundle: .module)
             case .contact:
-                return Text("CONTACT & SUPPORT", bundle: .module)
+                return Text("CONTACT_AND_SUPPORT", bundle: .module)
             }
         }
     }

--- a/SwiftPackage/Sources/BridgeClientUI/SingleStudy/Views/TodayView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/SingleStudy/Views/TodayView.swift
@@ -85,7 +85,7 @@ public struct TodayWrapperView: View {
     private func availabilityText(_ state: TodayTimelineSession.SessionState) -> Text {
         switch state {
         case .availableNow:
-            return Text("Current activities", bundle: .module)
+            return Text("CURRENT_ACTIVITIES", bundle: .module)
         case .upNext:
             return Text("Up next", bundle: .module)
         case .completed:

--- a/SwiftPackage/Sources/BridgeClientUI/Views/Components/CustomTabView.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/Views/Components/CustomTabView.swift
@@ -159,6 +159,7 @@ public struct CustomTabView<Tab : TabItem, Content : View>: View {
                 .padding(.top, imageTopOffset)
                 .frame(height: buttonSize - imageTopOffset, alignment: .top)
                 titles[tab]!
+                    .textCase(placement == .top ? .uppercase : nil)
                     .font(buttonFont[isSelected])
                     .foregroundColor(buttonColor[isSelected])
                     .scaledToFit()


### PR DESCRIPTION
The UI/UX includes capitalizing these words when they are used in a tab view. I was handling this by having the text in the localization file be all caps on the assumption that capitalization can affect the meaning of a word. However, Android isn't doing this and the translations are confused, so until someone who speaks Spanish tells me it's a bug, then all-caps is handled in the code. ¯\\_(ツ)_/¯ 