### PR TITLE
Handle http 410

### DIFF
--- a/bridge-client/src/androidMain/kotlin/org/sagebionetworks/bridge/kmm/shared/upload/UploadRequester.kt
+++ b/bridge-client/src/androidMain/kotlin/org/sagebionetworks/bridge/kmm/shared/upload/UploadRequester.kt
@@ -82,6 +82,10 @@ class UploadRequester(
     val pendingUploads get() = database.getResources(ResourceType.FILE_UPLOAD, APP_WIDE_STUDY_ID).isNotEmpty()
             || database.getResources(ResourceType.UPLOAD_SESSION, APP_WIDE_STUDY_ID).isNotEmpty()
 
+    fun getPendingFileUploads() : List<Resource> {
+        return database.getResources(ResourceType.FILE_UPLOAD, APP_WIDE_STUDY_ID)
+    }
+
 
 
     private fun getFile(filename: String): Path {

--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/BridgeErrorStatusNotifierFeature.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/BridgeErrorStatusNotifierFeature.kt
@@ -25,7 +25,7 @@ internal class BridgeErrorStatusNotifierFeature constructor(
     }
 
     companion object Feature : HttpClientPlugin<Config, BridgeErrorStatusNotifierFeature> {
-        override val key = AttributeKey<BridgeErrorStatusNotifierFeature>("SessionTokenFeature")
+        override val key = AttributeKey<BridgeErrorStatusNotifierFeature>("BridgeErrorStatusNotifierFeature")
 
         override fun prepare(block: Config.() -> Unit) = Config().apply(block).build()
 

--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/BridgeErrorStatusNotifierFeature.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/BridgeErrorStatusNotifierFeature.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.sagebionetworks.bridge.kmm.shared.apis
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.request.HttpRequestPipeline
+import io.ktor.client.request.header
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.util.AttributeKey
+import org.sagebionetworks.bridge.kmm.shared.apis.AbstractApi.Companion.BRIDGE_SERVER_CHECK
+
+internal class BridgeErrorStatusNotifierFeature constructor(
+    val statusNotifier: BridgeErrorStatusNotifier
+) {
+
+    class Config {
+        var statusNotifier: BridgeErrorStatusNotifier? = null
+        fun build() = BridgeErrorStatusNotifierFeature(
+            statusNotifier ?: throw IllegalArgumentException("statusNotifier cannot be null")
+        )
+    }
+
+    companion object Feature : HttpClientPlugin<Config, BridgeErrorStatusNotifierFeature> {
+        override val key = AttributeKey<BridgeErrorStatusNotifierFeature>("SessionTokenFeature")
+
+        override fun prepare(block: Config.() -> Unit) = Config().apply(block).build()
+
+        override fun install(feature: BridgeErrorStatusNotifierFeature, scope: HttpClient) {
+            scope.receivePipeline.intercept(HttpReceivePipeline.After) {
+                //Only applicable if we are making a call to Bridge server
+                if (subject.request.url.host.contains(AbstractApi.BRIDGE_SERVER_CHECK)) {
+                    if (subject.status.value in 400..499) {
+                        feature.statusNotifier.notifyUIOfBridgeError(subject.status)
+                    }
+                }
+            }
+        }
+    }
+}
+
+interface BridgeErrorStatusNotifier {
+    fun notifyUIOfBridgeError(statusCode: HttpStatusCode)
+}

--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/cache/ResourceType.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/cache/ResourceType.kt
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.kmm.shared.cache
 
+import io.ktor.http.*
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
@@ -28,7 +29,7 @@ enum class ResourceStatus {
 sealed class ResourceResult<out T : Any> {
     data class Success<out T : Any>(val data: T, val status: ResourceStatus) : ResourceResult<T>()
     //TODO: Failed reason -nbrown 12/4/20
-    data class Failed(val status: ResourceStatus) : ResourceResult<Nothing>()
+    data class Failed(val status: ResourceStatus, val httpStatusCode: HttpStatusCode? = null) : ResourceResult<Nothing>()
     object InProgress : ResourceResult<Nothing>()
 }
 

--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/di/HttpClientModule.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/di/HttpClientModule.kt
@@ -11,10 +11,7 @@ import kotlinx.serialization.json.Json
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.sagebionetworks.bridge.kmm.shared.BridgeConfig
-import org.sagebionetworks.bridge.kmm.shared.apis.EtagFeature
-import org.sagebionetworks.bridge.kmm.shared.apis.HttpUtil
-import org.sagebionetworks.bridge.kmm.shared.apis.RefreshTokenFeature
-import org.sagebionetworks.bridge.kmm.shared.apis.SessionTokenFeature
+import org.sagebionetworks.bridge.kmm.shared.apis.*
 import org.sagebionetworks.bridge.kmm.shared.cache.ResourceDatabaseHelper
 import org.sagebionetworks.bridge.kmm.shared.repo.AuthenticationProvider
 import org.sagebionetworks.bridge.kmm.shared.repo.AuthenticationRepository
@@ -88,6 +85,10 @@ internal fun HttpClient.appendDefaultConfig(
 
     install(EtagFeature) {
         storageCache = etagStorageCache
+    }
+
+    install(BridgeErrorStatusNotifierFeature) {
+        statusNotifier = authenticationRepository
     }
 
     install(SessionTokenFeature) {

--- a/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/TestUtils.kt
+++ b/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/TestUtils.kt
@@ -36,6 +36,10 @@ data class MockAuthenticationProvider(
         userSessionInfo = userSessionInfo?.copy(sessionToken = reauthSessionToken, reauthToken = reauthToken)
         return userSessionInfo != null
     }
+
+    override fun notifyUIOfBridgeError(statusCode: HttpStatusCode) {
+
+    }
 }
 
 fun createUserSessionInfo(sessionToken: String = "testSessionToken", reauthToken: String? = "reauthToken") : UserSessionInfo = UserSessionInfo(

--- a/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/TestUtils.kt
+++ b/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/TestUtils.kt
@@ -28,11 +28,17 @@ data class MockAuthenticationProvider(
     val reauthSessionToken: String = "newTestSessionToken",
     val reauthToken: String = "newReauthToken"
 ) : AuthenticationProvider {
+
+    var reauthCalled: Boolean = false
+    var sessionCallCount: Int = 0
+
     override fun session(): UserSessionInfo? {
+        sessionCallCount++
         return userSessionInfo
     }
 
     override suspend fun reAuth(): Boolean {
+        reauthCalled = true
         userSessionInfo = userSessionInfo?.copy(sessionToken = reauthSessionToken, reauthToken = reauthToken)
         return userSessionInfo != null
     }

--- a/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/TestUtils.kt
+++ b/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/TestUtils.kt
@@ -10,6 +10,7 @@ import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.json.Json
 import org.sagebionetworks.bridge.kmm.shared.apis.RefreshTokenFeature
 import org.sagebionetworks.bridge.kmm.shared.apis.SessionTokenFeature
@@ -18,6 +19,7 @@ import org.sagebionetworks.bridge.kmm.shared.cache.ResourceDatabaseHelper
 import org.sagebionetworks.bridge.kmm.shared.di.appendAuthConfig
 import org.sagebionetworks.bridge.kmm.shared.di.appendDefaultConfig
 import org.sagebionetworks.bridge.kmm.shared.models.UserSessionInfo
+import org.sagebionetworks.bridge.kmm.shared.repo.AppStatus
 import org.sagebionetworks.bridge.kmm.shared.repo.AuthenticationProvider
 import org.sagebionetworks.bridge.kmm.shared.repo.TestBridgeConfig
 
@@ -43,8 +45,11 @@ data class MockAuthenticationProvider(
         return userSessionInfo != null
     }
 
+    val appStatusMutable = MutableStateFlow(AppStatus.SUPPORTED)
     override fun notifyUIOfBridgeError(statusCode: HttpStatusCode) {
-
+        if (statusCode == HttpStatusCode.Gone) {
+            appStatusMutable.value = AppStatus.UNSUPPORTED
+        }
     }
 }
 

--- a/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/HttpRequestTests.kt
+++ b/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/HttpRequestTests.kt
@@ -75,7 +75,7 @@ class HttpRequestTests: BaseTest() {
             // Check the assumption that the broken auth provider returns non-null for the second request
             // (which then passes b/c the session token is still valid and not expired)
             assertNotNull(request2Headers)
-            assertEquals("testSessionToken", request1Headers!!.get("Bridge-Session"))
+            assertEquals("testSessionToken", request2Headers!!.get("Bridge-Session"))
 
             // Check that reauth was *not* called because the first session token != the second session token
             assertFalse(authProvider.reauthCalled)

--- a/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/HttpRequestTests.kt
+++ b/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/HttpRequestTests.kt
@@ -44,7 +44,7 @@ class HttpRequestTests: BaseTest() {
             var request2Headers: Headers? = null
 
             val mockEngine = MockEngine.config {
-                // 1 - Fail first call to simulate expired token
+                // 1 - Fail first call due to missing session token
                 addHandler {
                     request1Headers = it.headers
                     respondError(HttpStatusCode.Unauthorized)

--- a/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/AuthenticationRepoTest.kt
+++ b/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/AuthenticationRepoTest.kt
@@ -32,6 +32,27 @@ class AuthenticationRepoTest : BaseTest() {
 
             val response = authRepo.signInExternalId("typo:test_study", "typo:test_study")
             assertTrue(response is ResourceResult.Failed)
+            assertEquals(HttpStatusCode.NotFound, response.httpStatusCode)
+        }
+    }
+
+    @Test
+    fun testSignIn_410() {
+        runTest {
+
+            val json = "{\"statusCode\":410}"
+            val testConfig = TestHttpClientConfig(authProvider = null)
+
+            val authRepo = AuthenticationRepository(
+                getTestClient(json, HttpStatusCode.Gone, testConfig),
+                testConfig.bridgeConfig,
+                testConfig.db,
+                MainScope())
+
+            val response = authRepo.signInExternalId("typo:test_study", "typo:test_study")
+            assertTrue(response is ResourceResult.Failed)
+            assertEquals(HttpStatusCode.Gone, response.httpStatusCode)
+            assertEquals(AppStatus.UNSUPPORTED, authRepo.appStatus.value)
         }
     }
 }


### PR DESCRIPTION
Add a StateFlow that apps can observe to be notified of 410 app unsupported errors from Bridge. This will allow us to implement DHP-271 and DHP-272.