### PR TITLE
Add unit tests for reauth

### DIFF
--- a/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/TestUtils.kt
+++ b/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/TestUtils.kt
@@ -28,11 +28,17 @@ data class MockAuthenticationProvider(
     val reauthSessionToken: String = "newTestSessionToken",
     val reauthToken: String = "newReauthToken"
 ) : AuthenticationProvider {
+
+    var reauthCalled: Boolean = false
+    var sessionCallCount: Int = 0
+
     override fun session(): UserSessionInfo? {
+        sessionCallCount++
         return userSessionInfo
     }
 
     override suspend fun reAuth(): Boolean {
+        reauthCalled = true
         userSessionInfo = userSessionInfo?.copy(sessionToken = reauthSessionToken, reauthToken = reauthToken)
         return userSessionInfo != null
     }

--- a/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/HttpRequestTests.kt
+++ b/bridge-client/src/commonTest/kotlin/org/sagebionetworks/bridge/kmm/shared/apis/HttpRequestTests.kt
@@ -44,7 +44,7 @@ class HttpRequestTests: BaseTest() {
             var request2Headers: Headers? = null
 
             val mockEngine = MockEngine.config {
-                // 1 - Fail first call to simulate expired token
+                // 1 - Fail first call due to missing session token
                 addHandler {
                     request1Headers = it.headers
                     respondError(HttpStatusCode.Unauthorized)


### PR DESCRIPTION
- Test that reauth is called when the session token is present (and therefore getting 401 b/c it’s expired)
- Test that reauth is *not* called when the session token null (and therefore getting 401 b/c the call requires authentication)

I was looking to see if I could repro the auth calls that were being made b/c the initial call does not have a session token. Turns out that as a part of rewriting the HttpRequest config and fixing *those* errors, we also fixed this issue so my `MockBrokenAuthenticationProvider` test passes. I figure it's worth adding the tests anyway.

@dephillipsmichael 

Note: This does not address the other issues we are seeing such as the direct call to `reauth()` or why the session is returning null for a signed in user.