### PR TITLE
Add logging and always update the app state

### DIFF
--- a/SwiftPackage/Sources/BridgeClientExtension/UploadAppManager.swift
+++ b/SwiftPackage/Sources/BridgeClientExtension/UploadAppManager.swift
@@ -119,6 +119,8 @@ open class UploadAppManager : ObservableObject {
             return
         }
         
+        Logger.log(severity: .info, message: "Updating UserSessionInfo. updateType='\(updateType)', sessionToken='\(session?.sessionToken ?? "NULL")'")
+        
         self.session = session
         updateNetworkMonitoring()
         self.isNewLogin = (updateType == .login || updateType == .signout)
@@ -221,12 +223,14 @@ open class UploadAppManager : ObservableObject {
         self.authManager = NativeAuthenticationManager() { userSessionInfo in
             self.updateUserSessionStatus(userSessionInfo, updateType: .observed)
         }
+        Logger.log(severity: .info, message: "Getting current app status")
         self.bridgeAppStatus = self.authManager.currentAppStatus()
         self.authManager.observeAppStatus { status in
             DispatchQueue.main.async {
                 self.bridgeAppStatus = status
             }
         }
+        Logger.log(severity: .info, message: "Getting current session state")
         let userState = self.authManager.sessionState()
         self.userSessionInfo.loginError = userState.error
         if userState.error == nil {

--- a/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/AuthenticationRepository.kt
+++ b/bridge-client/src/commonMain/kotlin/org/sagebionetworks/bridge/kmm/shared/repo/AuthenticationRepository.kt
@@ -106,7 +106,7 @@ class AuthenticationRepository(
                 Logger.i("Signing out participant.")
                 authenticationApi.signOut(it)
             } catch (error: Throwable) {
-                Logger.w("Error signing out: $error")
+                Logger.e("Error signing out: $error")
             }
         }
         // Always clear database when signOut is called
@@ -205,7 +205,7 @@ class AuthenticationRepository(
             updateCachedSession(null, userSession)
             ResourceResult.Success(userSession, ResourceStatus.SUCCESS)
         } catch (err: Throwable) {
-            Logger.w("Error requesting reAuth with stored password: $err")
+            Logger.e("Error requesting reAuth with stored password: $err")
             if (err is ResponseException && err.response.status == HttpStatusCode.NotFound) {
                 ResourceResult.Failed(ResourceStatus.FAILED)
             } else {


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/DHP-849

Got into a weird situation where the participant account that I was logged in as had been deleted. This caused reauth to fail and the app got stuck on the launch screen. This calls updateAppState() after the reauth is no longer pending to refresh the app state.

The bug is still open b/c that state leads to a wacky loop of infinite retry where the app will keep pinging services w/o a valid session token.