### PR TITLE
Support archiving assessment results that adhere to Result interface

### DIFF
--- a/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentArchiver.kt
+++ b/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentArchiver.kt
@@ -167,7 +167,7 @@ class AssessmentArchiver(
             ArchiveFileInfo(
                 filename = resultData.filename,
                 timestamp = resultData.endDateTime?.toString() ?: Clock.System.now().toString(),
-                contentType = "application/json",
+                contentType = resultData.contentType,
                 identifier = resultData.identifier, // Mapped to Result.identifier
                 stepPath = stepPath,
                 jsonSchema = resultData.jsonSchema

--- a/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentArchiver.kt
+++ b/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentArchiver.kt
@@ -18,10 +18,10 @@ import org.sagebionetworks.bridge.kmm.shared.BridgeConfig
 import java.io.File
 
 class AssessmentArchiver(
-    private val assessmentResult: AssessmentResult,
+    private val assessmentResult: Result,
     private val jsonCoder: Json,
     private val bridgeConfig: BridgeConfig,
-    private val assessmentResultFilename: String
+    private val assessmentResultFilename: String // Used when result is of type AssessmentResult
 ) {
 
     private val manifest: MutableSet<ArchiveFileInfo> = mutableSetOf()
@@ -29,7 +29,7 @@ class AssessmentArchiver(
 
     init {
         val appVersion = "version ${bridgeConfig.appVersionName}, build ${bridgeConfig.appVersion}"
-        val item = assessmentResult.schemaIdentifier ?: assessmentResult.identifier
+        val item = assessmentResult.identifier
         archiveBuilder = Archive.Builder.forActivity(item)
             .withAppVersionName(appVersion)
             .withPhoneInfo(bridgeConfig.deviceName)
@@ -37,26 +37,31 @@ class AssessmentArchiver(
 
     fun buildArchive() : Archive {
         // Iterate through all the results within this collection and add if they are `JsonFileArchivableResult`.
-        addBranchResults(assessmentResult)
+        recursiveAdd(assessmentResult)
 
         //Add assessment result file to archive
-        Logger.d("Writing result for assessment ${assessmentResult.identifier}")
-        archiveBuilder.addDataFile(JsonArchiveFile(
-            assessmentResultFilename,
-            assessmentResult.endDateTime?.toJodaDateTime(),
-            jsonCoder.encodeToString(assessmentResult)
-        ))
-
-        //Add add assessment result file info to manifest
-        manifest.add(
-            ArchiveFileInfo(
-                filename = assessmentResultFilename,
-                timestamp = assessmentResult.endDateTime?.toString() ?: Clock.System.now().toString(),
-                contentType = "application/json",
-                identifier = assessmentResult.identifier,
-                jsonSchema = assessmentResult.jsonSchema
+        if (assessmentResult is AssessmentResult) {
+            Logger.d("Writing result for assessment ${assessmentResult.identifier}")
+            archiveBuilder.addDataFile(
+                JsonArchiveFile(
+                    assessmentResultFilename,
+                    assessmentResult.endDateTime?.toJodaDateTime(),
+                    jsonCoder.encodeToString(assessmentResult)
+                )
             )
-        )
+
+            //Add assessment result file info to manifest
+            manifest.add(
+                ArchiveFileInfo(
+                    filename = assessmentResultFilename,
+                    timestamp = assessmentResult.endDateTime?.toString() ?: Clock.System.now()
+                        .toString(),
+                    contentType = "application/json",
+                    identifier = assessmentResult.identifier,
+                    jsonSchema = assessmentResult.jsonSchema
+                )
+            )
+        }
 
         //Add metadata file
         val appVersion = "version ${bridgeConfig.appVersionName}, build ${bridgeConfig.appVersion}"

--- a/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentResultArchiveUploader.kt
+++ b/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentResultArchiveUploader.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import okio.ByteString.Companion.toByteString
 import org.sagebionetworks.assessmentmodel.AssessmentResult
+import org.sagebionetworks.assessmentmodel.Result
 import org.sagebionetworks.bridge.data.AndroidStudyUploadEncryptor
 import org.sagebionetworks.bridge.data.Archive
 import org.sagebionetworks.bridge.kmm.shared.upload.UploadFile
@@ -43,7 +44,7 @@ class AssessmentResultArchiveUploader(
      * Specifying a [sessionWindowExpiration] will delay the upload until after that point in time.
      * Subsequent calls to this method with the same [assessmentInstanceId] will replace any delayed uploads.
      */
-    fun archiveResultAndQueueUpload(assessmentResult: AssessmentResult,
+    fun archiveResultAndQueueUpload(assessmentResult: Result,
                                     jsonCoder: Json,
                                     assessmentInstanceId: String,
                                     eventTimestamp: String,
@@ -58,11 +59,11 @@ class AssessmentResultArchiveUploader(
             assessmentResultFilename = assessmentResultFilename
         )
 
-        val assessmentRunUUID =  if (assessmentResult.runUUIDString.isEmpty()) {
+        val assessmentRunUUID =  if (assessmentResult is AssessmentResult && assessmentResult.runUUIDString.isNotEmpty()) {
+            assessmentResult.runUUIDString
+        } else {
             Logger.e("No runUUIDString in assessmentResult, created")
             UUID.randomUUID().toString()
-        } else {
-            assessmentResult.runUUIDString
         }
 
         val uploadMetadata: Map<String, JsonElement> = mapOf(


### PR DESCRIPTION
This will will allow 3rd party assessments that already generate a JSON file, to simply return a FileResult and have it archive correctly.