### PR TITLE
Do not attempt orphan file upload until Kotlin db is hooked up

### DIFF
--- a/SwiftPackage/Sources/BridgeClientUI/BridgeClientAppManager.swift
+++ b/SwiftPackage/Sources/BridgeClientUI/BridgeClientAppManager.swift
@@ -42,45 +42,6 @@ public protocol ReauthPasswordHandler {
 /// 
 open class BridgeClientAppManager : UploadAppManager {
     
-    /// The  "state" of the app. SwiftUI relies upon observance patterns that do not work with Kotlin classes
-    /// because those classes are not threadsafe. The state handling of SwiftUI relies upon being able to
-    /// process observed changes on a background thread so the Kotlin classes must be wrapped. This
-    /// state enum is used to allow the app content view to change the UI to match the login state.
-    ///
-    /// - Example:
-    /// ```
-    ///    struct ContentView: View {
-    ///        @EnvironmentObject var bridgeManager: SingleStudyAppManager
-    ///        @StateObject var todayViewModel: TodayTimelineViewModel = .init()
-    ///
-    ///        var body: some View {
-    ///            switch bridgeManager.appState {
-    ///            case .launching:
-    ///                LaunchView()
-    ///            case .login:
-    ///                LoginView()
-    ///            case .onboarding:
-    ///                OnboardingView()
-    ///            case .main:
-    ///                MainView()
-    ///                    .environmentObject(todayViewModel)
-    ///                    .assessmentInfoMap(.init(extensions: MTBIdentifier.allCases))
-    ///                    .fullScreenCover(isPresented: $todayViewModel.isPresentingAssessment) {
-    ///                        MTBAssessmentView(todayViewModel)
-    ///                            .edgesIgnoringSafeArea(.all)
-    ///                    }
-    ///                    .statusBar(hidden: todayViewModel.isPresentingAssessment)
-    ///            }
-    ///        }
-    ///    }
-    /// ```
-    public enum AppState : String, StringEnumSet, Comparable {
-        case launching, login, onboarding, main, error
-    }
-    
-    /// The "state" of the app.
-    @Published public var appState: AppState = .launching
-    
     /// Has the participant been shown the onboarding flow?
     @Published public var isOnboardingFinished: Bool = UserDefaults.standard.bool(forKey: kOnboardingStateKey) {
         didSet {


### PR DESCRIPTION
The check for orphaned files needs to wait until after launch is done and kotlin is setup before checking for orphaned files.

Depending upon the app this can mean a whole bunch of steps that really should be sorted out *before* running the check. (MobileToolboxApp, for example, requires having a studyId set up as well as having a session token)

@dephillipsmichael This *might* fix your issue though I have another PR that I need to make on the DIAN app that may also be necessary.