### PR TITLE
Only check for V1 orphaned uploads if there may be some

### DIFF
--- a/SwiftPackage/Sources/BridgeClientExtension/File Uploading/V1/BridgeFileUploadManager.swift
+++ b/SwiftPackage/Sources/BridgeClientExtension/File Uploading/V1/BridgeFileUploadManager.swift
@@ -1085,6 +1085,7 @@ class BridgeFileUploadManager: SandboxFileManager, BridgeURLSessionDownloadDeleg
                 
                 // Update the app manager's isUploading status. This needs to be done on the main queue.
                 self.runOnQueue(OperationQueue.main, sync: false) {
+                    self.appManager.v1UploadsFinished = !uploading
                     self.appManager.isUploading = uploading
                 }
             }


### PR DESCRIPTION
This is a little change to reduce chatter in the logs (by only checking for V1 uploads if the flag is not previously set to "finished". This means that a fresh install will check once, but a reauth recovery won't get clobbered.