### PR TITLE
add "answers.json" file for Android

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/BridgeDigitalHealth/AssessmentModelKMM.git",
         "state": {
           "branch": null,
-          "revision": "ae36e6e3c097f58d1b71c4d383cd53a3c9110edf",
-          "version": "1.0.2"
+          "revision": "c69c70ccec06a41936a748057933922e94521d26",
+          "version": "1.0.3"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/BridgeDigitalHealth/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "cfab4b31cf7bdc7b9e8ab0ca9862936e9eac9257",
-          "version": "2.3.0"
+          "revision": "5d9acc0f5c1779cca3a31ca1913d684406e74f1f",
+          "version": "2.3.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/BridgeDigitalHealth/MobilePassiveData-SDK.git",
         "state": {
           "branch": null,
-          "revision": "725caa7bc926744796620e3baaa8477a454f27c1",
-          "version": "1.6.0"
+          "revision": "74a1f99da8f8c017d0a5adbb3584be81bb1cd9a8",
+          "version": "1.6.2"
         }
       },
       {

--- a/SwiftPackage/Sources/BridgeClientExtension/Data Archiving/AssessmentArchiveBuilder.swift
+++ b/SwiftPackage/Sources/BridgeClientExtension/Data Archiving/AssessmentArchiveBuilder.swift
@@ -174,8 +174,9 @@ open class AssessmentArchiveBuilder : ResultArchiveBuilder {
         }
         else if let answer = result as? AnswerResult,
                 let (value, jsonType) = answer.flatAnswer() {
-            answers[answer.identifier] = value
-            answersProperties[answer.identifier] = .primitive(.init(jsonType: jsonType, description: answer.questionText))
+            let key = path.replacingOccurrences(of: "/", with: "_")
+            answers[key] = value
+            answersProperties[key] = .primitive(.init(jsonType: jsonType, description: answer.questionText))
         }
     }
     

--- a/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentArchiver.kt
+++ b/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentArchiver.kt
@@ -1,16 +1,24 @@
 package org.sagebionetworks.bridge.assessmentmodel.upload
 
+import android.icu.text.CaseMap.Title
 import android.os.Build
 import co.touchlab.kermit.Logger
 import com.google.common.io.Files
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.sagebionetworks.assessmentmodel.*
+import org.sagebionetworks.assessmentmodel.survey.AnswerType
+import org.sagebionetworks.assessmentmodel.survey.BaseType
 import org.sagebionetworks.bridge.data.Archive
 import org.sagebionetworks.bridge.data.ByteSourceArchiveFile
 import org.sagebionetworks.bridge.data.JsonArchiveFile
@@ -26,6 +34,8 @@ class AssessmentArchiver(
 
     private val manifest: MutableSet<ArchiveFileInfo> = mutableSetOf()
     private val archiveBuilder: Archive.Builder
+    private var answers: MutableMap<String, JsonElement> = mutableMapOf()
+    private var answersSchema: SimpleJsonSchema
 
     init {
         val appVersion = "version ${bridgeConfig.appVersionName}, build ${bridgeConfig.appVersion}"
@@ -33,13 +43,14 @@ class AssessmentArchiver(
         archiveBuilder = Archive.Builder.forActivity(item)
             .withAppVersionName(appVersion)
             .withPhoneInfo(bridgeConfig.deviceName)
+        answersSchema = SimpleJsonSchema(description = assessmentResult.identifier)
     }
 
     fun buildArchive() : Archive {
         // Iterate through all the results within this collection and add if they are `JsonFileArchivableResult`.
         recursiveAdd(assessmentResult)
 
-        //Add assessment result file to archive
+        // Add assessment result file to archive
         if (assessmentResult is AssessmentResult) {
             Logger.d("Writing result for assessment ${assessmentResult.identifier}")
             archiveBuilder.addDataFile(
@@ -50,7 +61,7 @@ class AssessmentArchiver(
                 )
             )
 
-            //Add assessment result file info to manifest
+            // Add assessment result file info to manifest
             manifest.add(
                 ArchiveFileInfo(
                     filename = assessmentResultFilename,
@@ -63,7 +74,38 @@ class AssessmentArchiver(
             )
         }
 
-        //Add metadata file
+        // Add answers file and schema
+        if (answers.isNotEmpty()) {
+            val now = Clock.System.now()
+            val filename = "answers.json"
+            // Add the file to the archive
+            archiveBuilder.addDataFile(
+                JsonArchiveFile(
+                    filename,
+                    now.toJodaDateTime(),
+                    jsonCoder.encodeToString(answers)
+                )
+            )
+            // Add the schema to the archive
+            archiveBuilder.addDataFile(
+                JsonArchiveFile(
+                    answersSchema.id,
+                    now.toJodaDateTime(),
+                    jsonCoder.encodeToString(answersSchema)
+                )
+            )
+            // Add the linking between the answers and the schema to the metadata
+            manifest.add(
+                ArchiveFileInfo(
+                    filename = filename,
+                    timestamp = now.toString(),
+                    contentType = "application/json",
+                    jsonSchema = answersSchema.id
+                )
+            )
+        }
+
+        // Add metadata file
         val appVersion = "version ${bridgeConfig.appVersionName}, build ${bridgeConfig.appVersion}"
         val os = "${bridgeConfig.osName}/${bridgeConfig.osVersion}"
         val metadata =  ArchiveMetadata(
@@ -81,7 +123,7 @@ class AssessmentArchiver(
             )
         )
 
-        //Build and return the archive
+        // Build and return the archive
         return archiveBuilder.build()
     }
 
@@ -115,6 +157,9 @@ class AssessmentArchiver(
             }
             is FileResult -> {
                 addFileResult(result, path)
+            }
+            is AnswerResult -> {
+                addAnswerResult(result, path)
             }
         }
     }
@@ -176,6 +221,23 @@ class AssessmentArchiver(
         return true
     }
 
+    private fun addAnswerResult(result: AnswerResult, path: String) {
+        var baseType = result.answerType?.baseType ?: return
+        val key = path.replace("/", "_")
+        var jsonValue = result.jsonValue
+        if (baseType == BaseType.ARRAY) {
+            baseType = BaseType.STRING
+            jsonValue = jsonValue?.jsonArray?.let { array ->
+                val answers = array.map { it.toString() }
+                JsonPrimitive(answers.joinToString(","))
+            }
+        }
+        if (jsonValue != null) {
+            answers[key] = jsonValue
+        }
+        answersSchema.properties[key] = JsonSchemaProperty(baseType, result.questionText)
+    }
+
 }
 
 @Serializable
@@ -199,3 +261,21 @@ data class ArchiveFileInfo(
 
 fun Instant.toJodaDateTime(): DateTime = org.joda.time.Instant(this.toEpochMilliseconds())
     .toDateTime(DateTimeZone.UTC)
+
+@Serializable
+data class SimpleJsonSchema(
+    @SerialName("\$id")
+    val id: String = "answers_schema.json",
+    @SerialName("\$schema")
+    val schema: String = "http://json-schema.org/draft-07/schema#",
+    val type: String = "object",
+    val title: String = "answers_schema",
+    val description: String,
+    var properties: MutableMap<String, JsonSchemaProperty> = mutableMapOf()
+)
+
+@Serializable
+data class JsonSchemaProperty(
+    val type: BaseType,
+    val description: String?
+)


### PR DESCRIPTION
I also fixed a bug on the iOS implementation where sections weren't including the section in the path, which would result in identifiers clobbering each other.

This is a pretty bare-bones "build a table" implementation but it does account for the integer/double problem. It does not (on either iOS or Android) deal with formats for time/date, URL, significant digits, etc. that the fully featured `AnswerType` model object is designed to handle.