### PR TITLE
Adherence can be null for upload

### DIFF
--- a/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentResultArchiveUploader.kt
+++ b/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentResultArchiveUploader.kt
@@ -60,11 +60,11 @@ class AssessmentResultArchiveUploader(
             UUID.randomUUID().toString()
         }
 
-        val uploadMetadata = UploadMetadata(
-            instanceGuid = adherenceRecord?.instanceGuid,
-            eventTimestamp = adherenceRecord?.eventTimestamp,
-            startedOn = adherenceRecord?.startedOn?.toString()
-        )
+        val uploadMetadata = adherenceRecord?.let { UploadMetadata(
+            instanceGuid = it.instanceGuid,
+            eventTimestamp = it.eventTimestamp,
+            startedOn = it.startedOn?.toString()
+        )}
         val uploadFile = persist(assessmentRunUUID, archiver.buildArchive(), uploadMetadata)
         Logger.i("UploadFile $uploadFile")
         uploadRequester.queueAndRequestUpload(uploadFile)
@@ -75,7 +75,7 @@ class AssessmentResultArchiveUploader(
         CMSException::class,
         NoSuchAlgorithmException::class
     )
-    fun persist(filename: String, archive: Archive, uploadMetadata: UploadMetadata): UploadFile {
+    fun persist(filename: String, archive: Archive, uploadMetadata: UploadMetadata?): UploadFile {
         val md5: MessageDigest = try {
             MessageDigest.getInstance("MD5")
         } catch (e: NoSuchAlgorithmException) {

--- a/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentResultArchiveUploader.kt
+++ b/assessmentmodel-sdk/src/main/java/org/sagebionetworks/bridge/assessmentmodel/upload/AssessmentResultArchiveUploader.kt
@@ -43,8 +43,7 @@ class AssessmentResultArchiveUploader(
      */
     fun archiveResultAndQueueUpload(assessmentResult: Result,
                                     jsonCoder: Json,
-                                    assessmentInstanceId: String,
-                                    adherenceRecord: AdherenceRecord,
+                                    adherenceRecord: AdherenceRecord?,
                                     assessmentResultFilename: String? = "assessmentResult.json") {
 
         val archiver = AssessmentArchiver(
@@ -62,9 +61,9 @@ class AssessmentResultArchiveUploader(
         }
 
         val uploadMetadata = UploadMetadata(
-            instanceGuid = assessmentInstanceId,
-            eventTimestamp = adherenceRecord.eventTimestamp,
-            startedOn = adherenceRecord.startedOn?.toString()
+            instanceGuid = adherenceRecord?.instanceGuid,
+            eventTimestamp = adherenceRecord?.eventTimestamp,
+            startedOn = adherenceRecord?.startedOn?.toString()
         )
         val uploadFile = persist(assessmentRunUUID, archiver.buildArchive(), uploadMetadata)
         Logger.i("UploadFile $uploadFile")


### PR DESCRIPTION
The ARC app uploads a baseline assessment that doesn't have adherence associated with it. The UploadRepo already handles this correctly, just need to allow it through the AssessmentResultArchiveUploader that Android uses.