### PR TITLE
Add more logging to the V1 file uploader

### DIFF
--- a/SwiftPackage/Sources/BridgeClientExtension/File Uploading/V1/BridgeFileUploadManager.swift
+++ b/SwiftPackage/Sources/BridgeClientExtension/File Uploading/V1/BridgeFileUploadManager.swift
@@ -1042,11 +1042,13 @@ class BridgeFileUploadManager: SandboxFileManager, BridgeURLSessionDownloadDeleg
                     else {
                         continue
                 }
+                let uploadSuffix = "Uploads"
                 if isDirectory {
-                    if !name.hasSuffix("Uploads") {
+                    if !name.hasSuffix(uploadSuffix) {
                         dirEnumerator.skipDescendants()
                     }
-                } else {
+                } else if fileUrl.pathComponents.contains(where: { $0.hasSuffix(uploadSuffix) }) {
+                    // Exclude files at the base of the application support directory.
                     allFiles.append(fileUrl)
                 }
             }


### PR DESCRIPTION
Crashlytics is reporting that the V1 uploader is attempting to repeatedly upload an orphaned file with no attributes.

The device in question successfully uploaded the three files, but it looks like they were left behind and not deleted. I'm adding some additional logging to see if there is some pattern I can use to successfully mark the files as uploaded and delete them.

I figured out that files were being stored in the base directory of the "Application Support" directory and the uploader was counting those as orphaned files rather than skipping them.